### PR TITLE
Increase default sync timeout to 30s

### DIFF
--- a/src/MatrixClient.ts
+++ b/src/MatrixClient.ts
@@ -41,7 +41,7 @@ export class MatrixClient extends EventEmitter {
      *
      * Has no effect if the client is not syncing. Does not apply until the next sync request.
      */
-    public syncingTimeout = 10000;
+    public syncingTimeout = 30000;
 
     private userId: string;
     private requestId = 0;


### PR DESCRIPTION
10s feels quite low and certainly for my set of bots just generates lots of log lines. I'm not actually sure what metric should be used to determine the right default timeout value, but this feels low.