### PR TITLE
Fix bug with user & alias prefixes

### DIFF
--- a/src/appservice/Appservice.ts
+++ b/src/appservice/Appservice.ts
@@ -278,7 +278,7 @@ export class Appservice extends EventEmitter {
             this.aliasPrefix = null;
         } else {
             this.aliasPrefix = (this.registration.namespaces.aliases[0].regex || "").split(":")[0];
-            if (!this.aliasPrefix.endsWith(".*") || !this.aliasPrefix.endsWith(".+")) {
+            if (!this.aliasPrefix.endsWith(".*") && !this.aliasPrefix.endsWith(".+")) {
                 this.aliasPrefix = null;
             } else {
                 this.aliasPrefix = this.aliasPrefix.substring(0, this.aliasPrefix.length - 2); // trim off the .* part

--- a/src/appservice/Appservice.ts
+++ b/src/appservice/Appservice.ts
@@ -269,7 +269,7 @@ export class Appservice extends EventEmitter {
         }
 
         this.userPrefix = (this.registration.namespaces.users[0].regex || "").split(":")[0];
-        if (!this.userPrefix.endsWith(".*") || !this.userPrefix.endsWith(".+")) {
+        if (!this.userPrefix.endsWith(".*") && !this.userPrefix.endsWith(".+")) {
             throw new Error("Expected user namespace to be a prefix");
         }
         this.userPrefix = this.userPrefix.substring(0, this.userPrefix.length - 2); // trim off the .* part
@@ -405,7 +405,7 @@ export class Appservice extends EventEmitter {
      * @returns {string} The suffix from the user ID.
      */
     public getSuffixForUserId(userId: string): string {
-        if (!userId || !userId.startsWith(this.userPrefix) || !userId.endsWith(`:${this.options.homeserverName}`)) {
+        if (!userId || !userId.startsWith(this.userPrefix) && !userId.endsWith(`:${this.options.homeserverName}`)) {
             // Invalid ID
             return null;
         }

--- a/src/appservice/Appservice.ts
+++ b/src/appservice/Appservice.ts
@@ -405,7 +405,7 @@ export class Appservice extends EventEmitter {
      * @returns {string} The suffix from the user ID.
      */
     public getSuffixForUserId(userId: string): string {
-        if (!userId || !userId.startsWith(this.userPrefix) && !userId.endsWith(`:${this.options.homeserverName}`)) {
+        if (!userId || !userId.startsWith(this.userPrefix) || !userId.endsWith(`:${this.options.homeserverName}`)) {
             // Invalid ID
             return null;
         }

--- a/test/appservice/AppserviceTest.ts
+++ b/test/appservice/AppserviceTest.ts
@@ -125,6 +125,46 @@ describe('Appservice', () => {
         }
     });
 
+    it('should accept a ".+" prefix namespace', async () => {
+        const appservice = new Appservice({
+            port: 0,
+            bindAddress: '127.0.0.1',
+            homeserverName: 'localhost',
+            homeserverUrl: 'https://localhost',
+            registration: {
+                as_token: "",
+                hs_token: "",
+                sender_localpart: "",
+                namespaces: {
+                    users: [{exclusive: true, regex: "@prefix_.+:localhost"}],
+                    rooms: [],
+                    aliases: [],
+                },
+            },
+        });
+        expect(appservice.getUserIdForSuffix('foo')).toEqual("@prefix_foo:localhost");
+    });
+
+    it('should accept a ".*" prefix namespace', async () => {
+        const appservice = new Appservice({
+            port: 0,
+            bindAddress: '127.0.0.1',
+            homeserverName: 'localhost',
+            homeserverUrl: 'https://localhost',
+            registration: {
+                as_token: "",
+                hs_token: "",
+                sender_localpart: "",
+                namespaces: {
+                    users: [{exclusive: true, regex: "@prefix_.*:localhost"}],
+                    rooms: [],
+                    aliases: [],
+                },
+            },
+        });
+        expect(appservice.getUserIdForSuffix('foo')).toEqual("@prefix_foo:localhost");
+    });
+
     it('should return the right bot user ID', async () => {
         const appservice = new Appservice({
             port: 0,


### PR DESCRIPTION
We should check for either .+ or .* but not both.

This was broken by b684c66a8c4b9431cda55f2cd80c761429a77921