### PR TITLE
Fix getJoinedRoomMembersWithProfiles response format

### DIFF
--- a/src/MatrixClient.ts
+++ b/src/MatrixClient.ts
@@ -880,7 +880,7 @@ export class MatrixClient extends EventEmitter {
      * @returns {Object} The joined user IDs in the room as an object mapped to a set of profiles.
      */
     @timedMatrixClientFunctionCall()
-    public async getJoinedRoomMembersWithProfiles(roomId: string): Promise<{[userId: string]: MatrixProfileInfo}> {
+    public async getJoinedRoomMembersWithProfiles(roomId: string): Promise<{[userId: string]: {display_name?: string, avatar_url?: string}> {
         return (await this.doRequest("GET", "/_matrix/client/r0/rooms/" + encodeURIComponent(roomId) + "/joined_members")).joined;
     }
 

--- a/test/MatrixClientTest.ts
+++ b/test/MatrixClientTest.ts
@@ -2518,10 +2518,10 @@ describe('MatrixClient', () => {
             const roomId = "!testing:example.org";
             const members = {
                 "@alice:example.org": {
-                    displayname: "Alice of Wonderland"
+                    display_name: "Alice of Wonderland"
                 },
                 "@bob:example.org": {
-                    displayname: "Bob the Builder",
+                    display_name: "Bob the Builder",
                     avatar_url: "mxc://foo/bar"
                 }
             };


### PR DESCRIPTION
As per https://matrix.org/docs/spec/client_server/r0.6.0#get-matrix-client-r0-rooms-roomid-joined-members, `display_name` is correct.