### PR TITLE
Allow appservice user namespace to contain non .*|.+ suffixes

### DIFF
--- a/src/appservice/Appservice.ts
+++ b/src/appservice/Appservice.ts
@@ -270,8 +270,6 @@ export class Appservice extends EventEmitter {
 
         // Everything else can 404
 
-        // TODO: Should we permit other user namespaces and instead error when trying to use doSomethingBySuffix()?
-
         if (!this.registration.namespaces || !this.registration.namespaces.users || this.registration.namespaces.users.length === 0) {
             throw new Error("No user namespaces in registration");
         }

--- a/src/appservice/Appservice.ts
+++ b/src/appservice/Appservice.ts
@@ -266,7 +266,6 @@ export class Appservice extends EventEmitter {
             throw new Error("Too many user namespaces registered: expecting exactly one");
         }
 
-        // Only check if we've enabled
         let userPrefix = (this.registration.namespaces.users[0].regex || "").split(":")[0];
         if (!userPrefix.endsWith(".*") && !userPrefix.endsWith(".+")) {
             this.userPrefix = null;

--- a/src/appservice/Intent.ts
+++ b/src/appservice/Intent.ts
@@ -180,40 +180,40 @@ export class Intent {
 
     /**
      * Ensures the user is registered
-     * @returns {Promise<any>} Resolves when complete
+     * @returns {Promise<void>} Resolves when complete
      */
     @timedIntentFunctionCall()
-    public async ensureRegistered() {
-        if (!(await Promise.resolve(this.storage.isUserRegistered(this.userId)))) {
-            try {
-                const result = await this.client.doRequest("POST", "/_matrix/client/r0/register", null, {
-                    type: "m.login.application_service",
-                    username: this.userId.substring(1).split(":")[0],
-                });
+    public async ensureRegistered(): Promise<void> {
+        if ((await Promise.resolve(this.storage.isUserRegistered(this.userId)))) {
+            return;
+        }
+        try {
+            const result = await this.client.doRequest("POST", "/_matrix/client/r0/register", null, {
+                type: "m.login.application_service",
+                username: this.userId.substring(1).split(":")[0],
+            });
 
-                // HACK: Workaround for unit tests
-                if (result['errcode']) {
-                    // noinspection ExceptionCaughtLocallyJS
-                    throw {body: result};
-                }
-            } catch (err) {
-                if (typeof (err.body) === "string") err.body = JSON.parse(err.body);
-                if (err.body && err.body["errcode"] === "M_USER_IN_USE") {
-                    await Promise.resolve(this.storage.addRegisteredUser(this.userId));
-                    if (this.userId === this.appservice.botUserId) {
-                        return null;
-                    } else {
-                        LogService.error("Appservice", "Error registering user: User ID is in use");
-                        return null;
-                    }
+            // HACK: Workaround for unit tests
+            if (result['errcode']) {
+                // noinspection ExceptionCaughtLocallyJS
+                throw {body: result};
+            }
+        } catch (err) {
+            if (typeof (err.body) === "string") err.body = JSON.parse(err.body);
+            if (err.body && err.body["errcode"] === "M_USER_IN_USE") {
+                await Promise.resolve(this.storage.addRegisteredUser(this.userId));
+                if (this.userId === this.appservice.botUserId) {
+                    return null;
                 } else {
                     LogService.error("Appservice", "Encountered error registering user: ");
                     LogService.error("Appservice", extractRequestError(err));
                 }
-                throw err;
+            } else {
+                LogService.error("Appservice", "Encountered error registering user: ");
+                LogService.error("Appservice", err);
             }
-
-            await Promise.resolve(this.storage.addRegisteredUser(this.userId));
+            throw err;
         }
+        await Promise.resolve(this.storage.addRegisteredUser(this.userId));
     }
 }

--- a/test/appservice/AppserviceTest.ts
+++ b/test/appservice/AppserviceTest.ts
@@ -99,32 +99,6 @@ describe('Appservice', () => {
         }
     });
 
-    it('should throw when there is no prefix namespace', async () => {
-        try {
-            new Appservice({
-                port: 0,
-                bindAddress: '127.0.0.1',
-                homeserverName: 'localhost',
-                homeserverUrl: 'https://localhost',
-                registration: {
-                    as_token: "",
-                    hs_token: "",
-                    sender_localpart: "",
-                    namespaces: {
-                        users: [{exclusive: true, regex: "@.*_suffix:.+"}],
-                        rooms: [],
-                        aliases: [],
-                    },
-                },
-            });
-
-            // noinspection ExceptionCaughtLocallyJS
-            throw new Error("Did not throw when expecting it");
-        } catch (e) {
-            expect(e.message).toEqual("Expected user namespace to be a prefix");
-        }
-    });
-
     it('should accept a ".+" prefix namespace', async () => {
         const appservice = new Appservice({
             port: 0,
@@ -181,9 +155,9 @@ describe('Appservice', () => {
                     aliases: [],
                 },
             },
-            enableUserSuffixCheck: false,
         });
-        expect(() => appservice.getUserIdForSuffix('foo')).toThrowError("Cannot use getUserIdForSuffix, enableUserSuffixCheck is off");
+        expect(() => appservice.getUserIdForSuffix('foo')).toThrowError("Cannot use getUserIdForSuffix, provided namespace did not include a valid suffix");
+        expect(() => appservice.getSuffixForUserId('foo')).toThrowError("Cannot use getUserIdForSuffix, provided namespace did not include a valid suffix");
         expect(appservice.isNamespacedUser('@prefix_foo:localhost')).toEqual(true);
     });
 

--- a/test/appservice/AppserviceTest.ts
+++ b/test/appservice/AppserviceTest.ts
@@ -165,6 +165,28 @@ describe('Appservice', () => {
         expect(appservice.getUserIdForSuffix('foo')).toEqual("@prefix_foo:localhost");
     });
 
+    it('should allow disabling the suffix check', async () => {
+        const appservice = new Appservice({
+            port: 0,
+            bindAddress: '127.0.0.1',
+            homeserverName: 'localhost',
+            homeserverUrl: 'https://localhost',
+            registration: {
+                as_token: "",
+                hs_token: "",
+                sender_localpart: "",
+                namespaces: {
+                    users: [{exclusive: true, regex: "@prefix_foo:localhost"}],
+                    rooms: [],
+                    aliases: [],
+                },
+            },
+            enableUserSuffixCheck: false,
+        });
+        expect(() => appservice.getUserIdForSuffix('foo')).toThrowError("Cannot use getUserIdForSuffix, enableUserSuffixCheck is off");
+        expect(appservice.isNamespacedUser('@prefix_foo:localhost')).toEqual(true);
+    });
+
     it('should return the right bot user ID', async () => {
         const appservice = new Appservice({
             port: 0,


### PR DESCRIPTION
~This should not be a breaking change, as we add a new option to the Appservice class `enableUserSuffixCheck`.~

Following conversation with @turt2live & @madlittlemods, we're instead just going to throw in the functions

The rationale behind this change is that existing bridges (particularly those of the matrix-appservice-bridge class) have quite a range of namespace formats. The [Gitter bridges uses a very simple number regex](https://gitlab.com/gitterHQ/webapp/-/merge_requests/2245#note_654606818), for instance. I'd like to propose that developers should be able to disable the userPrefix check and instead opt out of functions which would require them to have a valid prefix.