### PR TITLE
Support MSC3395: Synthetic events

### DIFF
--- a/src/models/events/AppserviceSyntheticEvent.ts
+++ b/src/models/events/AppserviceSyntheticEvent.ts
@@ -1,0 +1,4 @@
+export interface MSC3395SyntheticEvent<T extends Object | unknown> {
+    type: string;
+    content: T;
+}

--- a/src/models/events/EventKind.ts
+++ b/src/models/events/EventKind.ts
@@ -13,4 +13,9 @@ export enum EventKind {
      * An ephemeral event, such as typing notifications or presence.
      */
     EphemeralEvent = "ephemeral",
+
+    /**
+     * An synthetic event, such as a user login or logout notification.
+     */
+    MSC3395SyntheticEvent = "synthetic",
 }


### PR DESCRIPTION
This implements the spec in https://github.com/matrix-org/matrix-doc/pull/3395. I've kept the types light (not providing enums for the event types) and expecting bridges to implement the handler logic for those.