### PR TITLE
Add exception type MatrixError

### DIFF
--- a/src/http.ts
+++ b/src/http.ts
@@ -1,6 +1,6 @@
 import { LogLevel, LogService } from "./logging/LogService";
 import { getRequestFn } from "./request";
-
+import MatrixError from './models/MatrixError';
 let lastRequestId = 0;
 
 /**
@@ -65,34 +65,38 @@ export function doHttpRequest(baseUrl: string, method: "GET"|"POST"|"PUT"|"DELET
             if (err) {
                 LogService.error("MatrixHttpClient (REQ-" + requestId + ")", err);
                 reject(err);
-            } else {
-                if (typeof (resBody) === 'string') {
-                    try {
-                        resBody = JSON.parse(resBody);
-                    } catch (e) {
-                    }
-                }
-
-                if (typeof (response.body) === 'string') {
-                    try {
-                        response.body = JSON.parse(response.body);
-                    } catch (e) {
-                    }
-                }
-
-                const respIsBuffer = (response.body instanceof Buffer);
-
-                // Don't log the body unless we're in debug mode. They can be large.
-                if (LogService.level.includes(LogLevel.TRACE)) {
-                    const redactedBody = respIsBuffer ? '<Buffer>' : redactObjectForLogging(response.body);
-                    LogService.trace("MatrixHttpClient (REQ-" + requestId + " RESP-H" + response.statusCode + ")", redactedBody);
-                }
-                if (response.statusCode < 200 || response.statusCode >= 300) {
-                    const redactedBody = respIsBuffer ? '<Buffer>' : redactObjectForLogging(response.body);
-                    LogService.error("MatrixHttpClient (REQ-" + requestId + ")", redactedBody);
-                    reject(response);
-                } else resolve(raw ? response : resBody);
+                return;
             }
+
+            if (typeof (resBody) === 'string') {
+                try {
+                    resBody = JSON.parse(resBody);
+                } catch (e) {
+                }
+            }
+
+            if (typeof (response.body) === 'string') {
+                try {
+                    response.body = JSON.parse(response.body);
+                } catch (e) {
+                }
+            }
+
+            const respIsBuffer = (response.body instanceof Buffer);
+
+            // Don't log the body unless we're in debug mode. They can be large.
+            if (LogService.level.includes(LogLevel.TRACE)) {
+                const redactedBody = respIsBuffer ? '<Buffer>' : redactObjectForLogging(response.body);
+                LogService.trace("MatrixHttpClient (REQ-" + requestId + " RESP-H" + response.statusCode + ")", redactedBody);
+            }
+            if (response.statusCode < 200 || response.statusCode >= 300) {
+                const redactedBody = respIsBuffer ? '<Buffer>' : redactObjectForLogging(response.body);
+                LogService.error("MatrixHttpClient (REQ-" + requestId + ")", redactedBody);
+                if ('errcode' in response.body) {
+                    reject(new MatrixError(response.body, response.statusCode));
+                }
+                reject(response);
+            } else resolve(raw ? response : resBody);
         });
     });
 }

--- a/src/models/MatrixError.ts
+++ b/src/models/MatrixError.ts
@@ -10,6 +10,6 @@ export default class MatrixError extends Error {
     }
 
     get message() {
-        return `Encountered a MatrixAPI error ${this.errcode}: ${this.error}`
+        return `${this.errcode}: ${this.error}`
     }
 }

--- a/src/models/MatrixError.ts
+++ b/src/models/MatrixError.ts
@@ -1,0 +1,15 @@
+export default class MatrixError extends Error {
+    public readonly errcode: string;
+    public readonly error: string;
+    public readonly retryAfterMs?: number;
+    constructor(public readonly body: {errcode: string, error: string, retry_after_ms?: number}, public readonly statusCode: number) {
+        super();
+        this.errcode = body.errcode;
+        this.error = body.error;
+        this.retryAfterMs = body.retry_after_ms;
+    }
+
+    get message() {
+        return `Encountered a MatrixAPI error ${this.errcode}: ${this.error}`
+    }
+}


### PR DESCRIPTION
This allows developers to catch and handle API errors in a uniform manner, and in the future allows us to move to another request library without breaking API compatibility.

This is inspired by https://github.com/matrix-org/matrix-js-sdk/blob/6098f74d8f43b325027e054659c937ab2caff6fa/src/http-api.js#L896-L916.

This came up in a meeting with @madlittlemods where we mentioned that it's a bit harder to track for errors now that the bridges have switched to using the matrix-bot-sdk, because the error thrown has changed.

I've tested this with one of the bridges, and it seems to be a marked improvement.