### PR TITLE
Add m.reaction and m.room.redaction event emitters

### DIFF
--- a/src/MatrixClient.ts
+++ b/src/MatrixClient.ts
@@ -844,8 +844,11 @@ export class MatrixClient extends EventEmitter {
                 }
                 if (event['type'] === 'm.room.message') {
                     await emitFn("room.message", roomId, event);
-                }
-                if (event['type'] === 'm.room.tombstone' && event['state_key'] === '') {
+                } if (event['type'] === 'm.reaction') {
+                    await emitFn("reaction", roomId, event);
+                } if (event['type'] === 'm.room.redaction') {
+                    await emitFn('room.redaction', roomId, event);
+                } if (event['type'] === 'm.room.tombstone' && event['state_key'] === '') {
                     await emitFn("room.archived", roomId, event);
                 }
                 if (event['type'] === 'm.room.create' && event['state_key'] === '' && event['content']


### PR DESCRIPTION
Please let me know if there should be tests/docs for this.

I'm unclear of why only a subset of all events are emitted - is that for simplicity or performance?

Cheers!