### PR TITLE
Make sure MatrixClient and HTTP modules are mute-able

### DIFF
--- a/src/MatrixClient.ts
+++ b/src/MatrixClient.ts
@@ -1503,14 +1503,14 @@ export class MatrixClient extends EventEmitter {
             };
             getRequestFn()(params, (err, response, resBody) => {
                 if (err) {
-                    LogService.error("MatrixLiteClient (REQ-" + requestId + ")", extractRequestError(err));
+                    LogService.error("MatrixClientLite", "(REQ-" + requestId + ")", extractRequestError(err));
                     reject(err);
                 } else {
                     const contentType = response.headers['content-type'] || "application/octet-stream";
 
-                    LogService.trace("MatrixLiteClient (REQ-" + requestId + " RESP-H" + response.statusCode + ")", "<data>");
+                    LogService.trace("MatrixClientLite", "(REQ-" + requestId + " RESP-H" + response.statusCode + ")", "<data>");
                     if (response.statusCode < 200 || response.statusCode >= 300) {
-                        LogService.error("MatrixLiteClient (REQ-" + requestId + ")", "<data>");
+                        LogService.error("MatrixClientLite", "(REQ-" + requestId + ")", "<data>");
                         reject(response);
                     } else resolve({body: resBody, contentType: contentType});
                 }

--- a/src/http.ts
+++ b/src/http.ts
@@ -27,13 +27,13 @@ export function doHttpRequest(baseUrl: string, method: "GET"|"POST"|"PUT"|"DELET
     const url = baseUrl + endpoint;
 
     // This is logged at info so that when a request fails people can figure out which one.
-    LogService.debug("MatrixHttpClient (REQ-" + requestId + ")", method + " " + url);
+    LogService.debug("MatrixHttpClient", "(REQ-" + requestId + ")", method + " " + url);
 
     // Don't log the request unless we're in debug mode. It can be large.
     if (LogService.level.includes(LogLevel.TRACE)) {
-        if (qs) LogService.trace("MatrixHttpClient (REQ-" + requestId + ")", "qs = " + JSON.stringify(qs));
-        if (body && !Buffer.isBuffer(body)) LogService.trace("MatrixHttpClient (REQ-" + requestId + ")", "body = " + JSON.stringify(this.redactObjectForLogging(body)));
-        if (body && Buffer.isBuffer(body)) LogService.trace("MatrixHttpClient (REQ-" + requestId + ")", "body = <Buffer>");
+        if (qs) LogService.trace("MatrixHttpClient", "(REQ-" + requestId + ")", "qs = " + JSON.stringify(qs));
+        if (body && !Buffer.isBuffer(body)) LogService.trace("MatrixHttpClient", "(REQ-" + requestId + ")", "body = " + JSON.stringify(this.redactObjectForLogging(body)));
+        if (body && Buffer.isBuffer(body)) LogService.trace("MatrixHttpClient", "(REQ-" + requestId + ")", "body = <Buffer>");
     }
 
     const params: { [k: string]: any } = {
@@ -63,7 +63,7 @@ export function doHttpRequest(baseUrl: string, method: "GET"|"POST"|"PUT"|"DELET
     return new Promise((resolve, reject) => {
         getRequestFn()(params, (err, response, resBody) => {
             if (err) {
-                LogService.error("MatrixHttpClient (REQ-" + requestId + ")", err);
+                LogService.error("MatrixHttpClient", "(REQ-" + requestId + ")", err);
                 reject(err);
             } else {
                 if (typeof (resBody) === 'string') {
@@ -85,11 +85,11 @@ export function doHttpRequest(baseUrl: string, method: "GET"|"POST"|"PUT"|"DELET
                 // Don't log the body unless we're in debug mode. They can be large.
                 if (LogService.level.includes(LogLevel.TRACE)) {
                     const redactedBody = respIsBuffer ? '<Buffer>' : redactObjectForLogging(response.body);
-                    LogService.trace("MatrixHttpClient (REQ-" + requestId + " RESP-H" + response.statusCode + ")", redactedBody);
+                    LogService.trace("MatrixHttpClient", "(REQ-" + requestId + " RESP-H" + response.statusCode + ")", redactedBody);
                 }
                 if (response.statusCode < 200 || response.statusCode >= 300) {
                     const redactedBody = respIsBuffer ? '<Buffer>' : redactObjectForLogging(response.body);
-                    LogService.error("MatrixHttpClient (REQ-" + requestId + ")", redactedBody);
+                    LogService.error("MatrixHttpClient", "(REQ-" + requestId + ")", redactedBody);
                     reject(response);
                 } else resolve(raw ? response : resBody);
             }


### PR DESCRIPTION
Not to be confused with mutable :) This makes their module names
consistent in their respective files, whic makes LogService.muteModule()
effective as intended.