### PR TITLE
Migrate delete room api to v2

### DIFF
--- a/src/SynapseAdminApis.ts
+++ b/src/SynapseAdminApis.ts
@@ -283,6 +283,16 @@ export class SynapseAdminApis {
      * @returns {Promise} Resolves when complete.
      */
     public async deleteRoom(roomId: string): Promise<void> {
-        return this.client.doRequest("POST", `/_synapse/admin/v1/rooms/${encodeURIComponent(roomId)}/delete`, {}, {purge: true});
+        return this.client.doRequest("DELETE", `/_synapse/admin/v2/rooms/${encodeURIComponent(roomId)}`, {}, {purge: true});
+    }
+
+    /**
+     * Gets the status of all active deletion tasks, and all those completed in the last 24h, for the given room_id.
+     * @param {string} roomId The room ID to get deletion state for.
+     * @returns {Promise<any[]>} Resolves to the room's deletion status results.
+     */
+    public async getDeleteRoomState(roomId: string): Promise<any[]> {
+        const r = await this.client.doRequest("GET", `/_synapse/admin/v2/rooms/${encodeURIComponent(roomId)}/delete_status`);
+        return r?.['results'] || [];
     }
 }

--- a/test/SynapseAdminApisTest.ts
+++ b/test/SynapseAdminApisTest.ts
@@ -310,9 +310,31 @@ describe('SynapseAdminApis', () => {
 
                 const roomId = "!room:example.org";
                 const state = [
-                    {content: {}, state_key: "", type: "m.room.create"},
-                    {content: {membership: "join"}, state_key: "@alice:example.org", type: "m.room.member"},
-                    {content: {membership: "leave"}, state_key: "@bob:example.org", type: "m.room.member"},
+                    {
+                        "delete_id": "delete_id1",
+                        "status": "failed",
+                        "error": "error message",
+                        "shutdown_room": {
+                            "kicked_users": [],
+                            "failed_to_kick_users": [],
+                            "local_aliases": [],
+                            "new_room_id": null
+                        }
+                    }, {
+                        "delete_id": "delete_id2",
+                        "status": "purging",
+                        "shutdown_room": {
+                            "kicked_users": [
+                                "@foobar:example.com"
+                            ],
+                            "failed_to_kick_users": [],
+                            "local_aliases": [
+                                "#badroom:example.com",
+                                "#evilsaloon:example.com"
+                            ],
+                            "new_room_id": "!newroomid:example.com"
+                        }
+                    }
                 ];
 
                 http.when("GET", "/_synapse/admin/v2/rooms").respond(200, (path, _content, req) => {


### PR DESCRIPTION
This PR migrates the delete room admin api to the new v2 as described here: https://matrix-org.github.io/synapse/latest/admin_api/rooms.html#version-2-new-version

This change is necessary because v1 has already been removed: https://github.com/matrix-org/synapse/blob/develop/CHANGES.md#synapse-1470rc1-2021-11-09 

https://github.com/matrix-org/synapse/issues/11213