### PR TITLE
Improve stack traces thrown from client functions

### DIFF
--- a/src/http.ts
+++ b/src/http.ts
@@ -63,16 +63,16 @@ export async function doHttpRequest(baseUrl: string, method: "GET"|"POST"|"PUT"|
     }
 
     const {response, resBody} = await new Promise<{response: any, resBody: any}>((resolve, reject) => {
-        getRequestFn()(params, (err, res, resBody) => {
+        getRequestFn()(params, (err, res, rBody) => {
             if (err) {
                 LogService.error("MatrixHttpClient", "(REQ-" + requestId + ")", err);
                 reject(err);
                 return;
             }
 
-            if (typeof (resBody) === 'string') {
+            if (typeof (rBody) === 'string') {
                 try {
-                    resBody = JSON.parse(resBody);
+                    rBody = JSON.parse(resBody);
                 } catch (e) {
                 }
             }
@@ -84,7 +84,7 @@ export async function doHttpRequest(baseUrl: string, method: "GET"|"POST"|"PUT"|
                 }
             }
 
-            resolve({response: res, resBody});
+            resolve({response: res, resBody: rBody});
         });
     });
 
@@ -92,7 +92,7 @@ export async function doHttpRequest(baseUrl: string, method: "GET"|"POST"|"PUT"|
 
     // Check for errors.
     const errBody = response.body || resBody;
-    if (errBody && 'errcode' in errBody) {
+    if (typeof (errBody) === "object" && 'errcode' in errBody) {
         const redactedBody = respIsBuffer ? '<Buffer>' : redactObjectForLogging(errBody);
         LogService.error("MatrixHttpClient (REQ-" + requestId + ")", redactedBody);
         throw new MatrixError(errBody, response.statusCode);

--- a/src/http.ts
+++ b/src/http.ts
@@ -72,7 +72,7 @@ export async function doHttpRequest(baseUrl: string, method: "GET"|"POST"|"PUT"|
 
             if (typeof (rBody) === 'string') {
                 try {
-                    rBody = JSON.parse(resBody);
+                    rBody = JSON.parse(rBody);
                 } catch (e) {
                 }
             }
@@ -109,7 +109,7 @@ export async function doHttpRequest(baseUrl: string, method: "GET"|"POST"|"PUT"|
         LogService.error("MatrixHttpClient (REQ-" + requestId + ")", redactedBody);
         throw response;
     }
-    return (raw ? response : resBody);
+    return raw ? response : resBody;
 }
 
 export function redactObjectForLogging(input: any): any {

--- a/src/http.ts
+++ b/src/http.ts
@@ -96,7 +96,6 @@ export async function doHttpRequest(baseUrl: string, method: "GET"|"POST"|"PUT"|
         const redactedBody = respIsBuffer ? '<Buffer>' : redactObjectForLogging(errBody);
         LogService.error("MatrixHttpClient (REQ-" + requestId + ")", redactedBody);
         throw new MatrixError(errBody, response.statusCode);
-        return;
     }
 
     // Don't log the body unless we're in debug mode. They can be large.

--- a/src/metrics/decorators.ts
+++ b/src/metrics/decorators.ts
@@ -32,7 +32,7 @@ export function timedMatrixClientFunctionCall() {
                 this.metrics.increment(METRIC_MATRIX_CLIENT_FAILED_FUNCTION_CALL, context, 1);
                 throw e;
             } finally {
-                this.metrics.end(METRIC_MATRIX_CLIENT_FUNCTION_CALL, context)
+                this.metrics.end(METRIC_MATRIX_CLIENT_FUNCTION_CALL, context);
             }
         };
     };
@@ -59,7 +59,7 @@ export function timedIdentityClientFunctionCall() {
                 this.metrics.increment(METRIC_IDENTITY_CLIENT_FAILED_FUNCTION_CALL, context, 1);
                 throw e;
             } finally {
-                this.metrics.end(METRIC_IDENTITY_CLIENT_FUNCTION_CALL, context)
+                this.metrics.end(METRIC_IDENTITY_CLIENT_FUNCTION_CALL, context);
             }
         }
     };
@@ -87,7 +87,7 @@ export function timedIntentFunctionCall() {
                 this.metrics.increment(METRIC_INTENT_FAILED_FUNCTION_CALL, context, 1);
                 throw e;
             } finally {
-                this.metrics.end(METRIC_INTENT_FUNCTION_CALL, context)
+                this.metrics.end(METRIC_INTENT_FUNCTION_CALL, context);
             }
         }
     };

--- a/src/metrics/decorators.ts
+++ b/src/metrics/decorators.ts
@@ -43,7 +43,7 @@ export function timedMatrixClientFunctionCall() {
  * @category Metrics
  */
 export function timedIdentityClientFunctionCall() {
-    return function (_target: never, functionName: string, descriptor: PropertyDescriptor) {
+    return function (_target: unknown, functionName: string, descriptor: PropertyDescriptor) {
         const originalMethod = descriptor.value;
         descriptor.value = async function (...args: any[]) {
             const context = this.metrics.assignUniqueContextId(<IdentityClientCallContext>{
@@ -70,7 +70,7 @@ export function timedIdentityClientFunctionCall() {
  * @category Metrics
  */
 export function timedIntentFunctionCall() {
-    return function (_target: never, functionName: string, descriptor: PropertyDescriptor) {
+    return function (_target: unknown, functionName: string, descriptor: PropertyDescriptor) {
         const originalMethod = descriptor.value;
         descriptor.value = async function (...args: any[]) {
             const context = this.metrics.assignUniqueContextId(<IntentCallContext>{

--- a/src/metrics/decorators.ts
+++ b/src/metrics/decorators.ts
@@ -16,7 +16,7 @@ import { IdentityClientCallContext, IntentCallContext, MatrixClientCallContext }
  * @category Metrics
  */
 export function timedMatrixClientFunctionCall() {
-    return function (_target: never, functionName: string, descriptor: PropertyDescriptor) {
+    return function (_target: unknown, functionName: string, descriptor: PropertyDescriptor) {
         const originalMethod = descriptor.value;
         descriptor.value = async function (...args) {
             const context = this.metrics.assignUniqueContextId(<MatrixClientCallContext>{
@@ -46,9 +46,7 @@ export function timedIdentityClientFunctionCall() {
     return function (_target: never, functionName: string, descriptor: PropertyDescriptor) {
         const originalMethod = descriptor.value;
         descriptor.value = async function (...args: any[]) {
-            const metrics = this.metrics;
-
-            const context = metrics.assignUniqueContextId(<IdentityClientCallContext>{
+            const context = this.metrics.assignUniqueContextId(<IdentityClientCallContext>{
                 functionName,
                 client: this,
             });
@@ -75,9 +73,7 @@ export function timedIntentFunctionCall() {
     return function (_target: never, functionName: string, descriptor: PropertyDescriptor) {
         const originalMethod = descriptor.value;
         descriptor.value = async function (...args: any[]) {
-            const metrics = this.metrics;
-
-            const context = metrics.assignUniqueContextId(<IntentCallContext>{
+            const context = this.metrics.assignUniqueContextId(<IntentCallContext>{
                 functionName,
                 client: this.client,
                 intent: this,

--- a/src/metrics/decorators.ts
+++ b/src/metrics/decorators.ts
@@ -16,40 +16,25 @@ import { IdentityClientCallContext, IntentCallContext, MatrixClientCallContext }
  * @category Metrics
  */
 export function timedMatrixClientFunctionCall() {
-    return function (target: any, propertyKey: string, descriptor: PropertyDescriptor) {
+    return function (_target: never, functionName: string, descriptor: PropertyDescriptor) {
         const originalMethod = descriptor.value;
-        descriptor.value = function (...args: any[]) {
-            const metrics = this.metrics;
-
-            const context = metrics.assignUniqueContextId(<MatrixClientCallContext>{
-                functionName: propertyKey,
+        descriptor.value = async function (...args) {
+            const context = this.metrics.assignUniqueContextId(<MatrixClientCallContext>{
+                functionName,
                 client: this,
             });
-            metrics.start(METRIC_MATRIX_CLIENT_FUNCTION_CALL, context);
-
-            let result;
-            let exception;
-
+            this.metrics.start(METRIC_MATRIX_CLIENT_FUNCTION_CALL, context);
             try {
-                result = originalMethod.apply(this, args);
+                const result = await originalMethod.apply(this, args);
+                this.metrics.increment(METRIC_MATRIX_CLIENT_SUCCESSFUL_FUNCTION_CALL, context, 1);
+                return result;
             } catch (e) {
-                exception = e;
-                result = Promise.reject(e);
+                this.metrics.increment(METRIC_MATRIX_CLIENT_FAILED_FUNCTION_CALL, context, 1);
+                throw e;
+            } finally {
+                this.metrics.end(METRIC_MATRIX_CLIENT_FUNCTION_CALL, context)
             }
-
-            let promise = result;
-            if (!(result instanceof Promise) && result !== null && result !== undefined) {
-                promise = Promise.resolve(result);
-            }
-
-            promise
-                .then(() => metrics.increment(METRIC_MATRIX_CLIENT_SUCCESSFUL_FUNCTION_CALL, context, 1))
-                .catch(() => metrics.increment(METRIC_MATRIX_CLIENT_FAILED_FUNCTION_CALL, context, 1))
-                .finally(() => metrics.end(METRIC_MATRIX_CLIENT_FUNCTION_CALL, context));
-
-            if (exception) throw exception;
-            return result;
-        }
+        };
     };
 }
 
@@ -58,39 +43,26 @@ export function timedMatrixClientFunctionCall() {
  * @category Metrics
  */
 export function timedIdentityClientFunctionCall() {
-    return function (target: any, propertyKey: string, descriptor: PropertyDescriptor) {
+    return function (_target: never, functionName: string, descriptor: PropertyDescriptor) {
         const originalMethod = descriptor.value;
-        descriptor.value = function (...args: any[]) {
+        descriptor.value = async function (...args: any[]) {
             const metrics = this.metrics;
 
             const context = metrics.assignUniqueContextId(<IdentityClientCallContext>{
-                functionName: propertyKey,
+                functionName,
                 client: this,
             });
-            metrics.start(METRIC_IDENTITY_CLIENT_FUNCTION_CALL, context);
-
-            let result;
-            let exception;
-
+            this.metrics.start(METRIC_IDENTITY_CLIENT_FUNCTION_CALL, context);
             try {
-                result = originalMethod.apply(this, args);
+                const result = await originalMethod.apply(this, args);
+                this.metrics.increment(METRIC_IDENTITY_CLIENT_SUCCESSFUL_FUNCTION_CALL, context, 1);
+                return result;
             } catch (e) {
-                exception = e;
-                result = Promise.reject(e);
+                this.metrics.increment(METRIC_IDENTITY_CLIENT_FAILED_FUNCTION_CALL, context, 1);
+                throw e;
+            } finally {
+                this.metrics.end(METRIC_IDENTITY_CLIENT_FUNCTION_CALL, context)
             }
-
-            let promise = result;
-            if (!(result instanceof Promise) && result !== null && result !== undefined) {
-                promise = Promise.resolve(result);
-            }
-
-            promise
-                .then(() => metrics.increment(METRIC_IDENTITY_CLIENT_SUCCESSFUL_FUNCTION_CALL, context, 1))
-                .catch(() => metrics.increment(METRIC_IDENTITY_CLIENT_FAILED_FUNCTION_CALL, context, 1))
-                .finally(() => metrics.end(METRIC_IDENTITY_CLIENT_FUNCTION_CALL, context));
-
-            if (exception) throw exception;
-            return result;
         }
     };
 }
@@ -100,40 +72,27 @@ export function timedIdentityClientFunctionCall() {
  * @category Metrics
  */
 export function timedIntentFunctionCall() {
-    return function (target: any, propertyKey: string, descriptor: PropertyDescriptor) {
+    return function (_target: never, functionName: string, descriptor: PropertyDescriptor) {
         const originalMethod = descriptor.value;
-        descriptor.value = function (...args: any[]) {
+        descriptor.value = async function (...args: any[]) {
             const metrics = this.metrics;
 
             const context = metrics.assignUniqueContextId(<IntentCallContext>{
-                functionName: propertyKey,
+                functionName,
                 client: this.client,
                 intent: this,
             });
-            metrics.start(METRIC_INTENT_FUNCTION_CALL, context);
-
-            let result;
-            let exception;
-
+            this.metrics.start(METRIC_INTENT_FUNCTION_CALL, context);
             try {
-                result = originalMethod.apply(this, args);
+                const result = await originalMethod.apply(this, args);
+                this.metrics.increment(METRIC_INTENT_SUCCESSFUL_FUNCTION_CALL, context, 1);
+                return result;
             } catch (e) {
-                exception = e;
-                result = Promise.reject(e);
+                this.metrics.increment(METRIC_INTENT_FAILED_FUNCTION_CALL, context, 1);
+                throw e;
+            } finally {
+                this.metrics.end(METRIC_INTENT_FUNCTION_CALL, context)
             }
-
-            let promise = result;
-            if (!(result instanceof Promise) && result !== null && result !== undefined) {
-                promise = Promise.resolve(result);
-            }
-
-            promise
-                .then(() => metrics.increment(METRIC_INTENT_SUCCESSFUL_FUNCTION_CALL, context, 1))
-                .catch(() => metrics.increment(METRIC_INTENT_FAILED_FUNCTION_CALL, context, 1))
-                .finally(() => metrics.end(METRIC_INTENT_FUNCTION_CALL, context));
-
-            if (exception) throw exception;
-            return result;
         }
     };
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "emitDecoratorMetadata": true,
     "module": "commonjs",
     "moduleResolution": "node",
-    "target": "es2015",
+    "target": "es2020",
     "noImplicitAny": false,
     "sourceMap": false,
     "outDir": "./lib",


### PR DESCRIPTION
Currently, stack traces are rather unhelpful when thrown from MatrixClient functions:

```
     Error: M_FORBIDDEN: Application service has not registered this user (@redacted)
      at /redacted/matrix-bot-sdk/lib/http.js:105:19
      at Generator.next (<anonymous>)
      at fulfilled (/redacted/matrix-bot-sdk/lib/http.js:5:58)
      at processTicksAndRejections (internal/process/task_queues.js:95:5)
```

This doesn't really give away where the problem actually came from in the source. This PR does 3 things to resolve this:

- Throwing an error `doHttpRequest` directly, rather than inside the handler function for request. This reduces the amount of cruft in the stack trace. This did require a bit of rejiggling, and also fixed a bug introduced where non-JSON non-200 bodies would cause issues.
- Using ES2020 for Typescript compilation. This project was on 2015, which meant that async funcs were wrapped in generators. I'd imagine this also comes with a performance improvement, but at the very least using native async gives node a chance to report something sensible.
- Most importantly: The metrics decorator functions were obscuring the error somewhat with the way they handled calling their parent function. I believe the changes I've introduced don't come with any functionality changes, have definitely improved the stack traces and have tripped down the LOC for each decorator.

The new stack traces look like:

```
DEBUG 15:46:00:404 [MatrixHttpClient] (REQ-1) PUT http://localhost:8008/_matrix/client/r0/rooms/NotARoom/send/m.room.message/1651761960404__inc1
ERROR 15:46:00:420 [MatrixHttpClient (REQ-1)] { errcode: 'M_FORBIDDEN', error: 'Unknown room' }
ERROR 15:46:00:442 [App] BridgeApp encountered an error and has stopped: MatrixError: M_FORBIDDEN: Unknown room
    at doHttpRequest (/reacted/lib/http.js:95:15)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at MatrixClient.descriptor.value (/reacted/lib/metrics/decorators.js:21:26)
    at MatrixClient.descriptor.value (/reacted/lib/metrics/decorators.js:21:26)
    at MatrixClient.descriptor.value (/reacted/lib/metrics/decorators.js:21:26)
    at MatrixClient.descriptor.value (/reacted/lib/metrics/decorators.js:21:26)
    at MatrixClient.descriptor.value (/reacted/lib/metrics/decorators.js:21:26)
    at Bridge.start (/home/will/git/matrix-hookshot/src/Bridge.ts:91:9)
    at start (/home/will/git/matrix-hookshot/src/App/BridgeApp.ts:39:5) {
  body: { errcode: 'M_FORBIDDEN', error: 'Unknown room' },
  statusCode: 403,
  errcode: 'M_FORBIDDEN',
  error: 'Unknown room',
  retryAfterMs: undefined
}
```

Which while introduce a bit more cruft when several decorators are used in a chain, it also gives you a hint as to where the function call originated from.