### PR TITLE
Use LogService as express log handler

### DIFF
--- a/src/appservice/Appservice.ts
+++ b/src/appservice/Appservice.ts
@@ -268,7 +268,9 @@ export class Appservice extends EventEmitter {
         this.cryptoStorage = options.cryptoStorage;
 
         this.app.use(express.json({limit: Number.MAX_SAFE_INTEGER})); // disable limits, use a reverse proxy
-        this.app.use(morgan("combined"));
+        this.app.use(morgan("combined", {
+            stream: { write: LogService.info.bind(LogService, 'Appservice') }
+        }));
 
         // ETag headers break the tests sometimes, and we don't actually need them anyways for
         // appservices - none of this should be cached.


### PR DESCRIPTION
This makes it as configurable (and as mute-able) as the rest of bot-sdk logs,
instead of always landing on stdout.

Two regressions/changes that this currently brings:

1. Since LogService prefixes every logline with the name of the module that spat it out, this changes the access.log format by prefixing it all with `Appservice`. Not sure if this is a huge deal since the logs are far too noisy right now to treat them as structured & predictable access logs
2. This adds an extra newline at the end due to both morgan and LogService adding their own