### PR TITLE
Add the ability to transparently cache room state via sync.

### DIFF
--- a/src/state/RoomState.ts
+++ b/src/state/RoomState.ts
@@ -1,0 +1,49 @@
+export class RoomState {
+
+    // A map of state events indexed first by state type and then state keys.
+    private stateByType: Map<string, Map<string, any>> = new Map();
+
+    constructor(public readonly roomId: string) {
+    }
+
+    /**
+     * Store this state event as part of the active room state.
+     * @param stateType The event type e.g. m.room.policy.user.
+     * @param stateKey The state key e.g. rule:@bad:matrix.org
+     * @param event A state event to store.
+     */
+    private setState(stateType: string, stateKey: string, event: any): void {
+        let typeTable = this.stateByType.get(stateType);
+        if (typeTable) {
+            typeTable.set(stateKey, event);
+        } else {
+            this.stateByType.set(stateType, new Map().set(stateKey, event));
+        }
+    }
+
+    /**
+     * Lookup the current state cached for the room.
+     * @param stateType The event type e.g. m.policy.rule.user.
+     * @param stateKey The state key e.g. rule:@bad:matrix.org
+     * @returns A state event if present or undefined.
+     */
+    public getStateEvent(stateType: string, stateKey: string) {
+        return this.stateByType.get(stateType)?.get(stateKey);
+    }
+
+    /**
+     * @returns All of the state events within the room or undefined.
+     */
+    public getRoomState(): any[] {
+        const stateKeyMaps = Array.from(this.stateByType.values());
+        return [...stateKeyMaps.map(stateKeyMap => Array.from(stateKeyMap.values()))];
+    }
+
+    /**
+     * Update the room state for a new state event.
+     * @param event A new state event from the `state` response of `/sync`.
+     */
+    public updateForEvent(event: any): void {
+        this.setState(event.type, event.state_key, event);
+    }
+}

--- a/src/state/RoomStateCache.ts
+++ b/src/state/RoomStateCache.ts
@@ -1,0 +1,65 @@
+import { MatrixClient } from "..";
+import { LogService } from "../logging/LogService";
+import { RoomState } from "./RoomState";
+
+export default class RoomStateCache {
+    private rooms = new Map<string /* room id */, RoomState>();
+
+    constructor(client: MatrixClient) {
+        client.on('room.leave', (roomId: string) => {
+            this.rooms.delete(roomId);
+        })
+    }
+
+    private getRoom(roomId: string): RoomState {
+        const room = this.rooms.get(roomId);
+        if (room !== undefined) {
+            return room;
+        } else {
+            const newRoom = new RoomState(roomId);
+            this.rooms.set(roomId, newRoom);
+            return newRoom;
+        }
+    }
+
+    /**
+     * Mirrors the `MatrixClient` interface for processing sync.
+     * Updates the cache by extracting state updates from `state`.
+     * @param raw The entire raw sync response.
+     */
+    public processSync(raw: any): void {
+        if (!raw) return; // nothing to process
+        let joinedRooms = (raw['rooms'] ?? {})['join'] || {};
+        for (let [roomId, room] of Object.entries(joinedRooms)) {
+            const events = (room['state'] ?? {})['events'] ?? [];
+            if (events.length > 0) {
+                const roomState = this.getRoom(roomId);
+                events.forEach(roomState.updateForEvent, roomState);
+            }
+        }
+    }
+
+    /**
+     * Mirrors the `MatrixClient` interface for getting a room state event from
+     * https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3roomsroomidstateeventtypestatekey
+     * with the intention that it can be used as a transparent replacement.
+     * @param roomId The room to get the room state from.
+     * @param type The event type.
+     * @param stateKey The state key of the event.
+     * @returns The content of the state event.
+     */
+    public getRoomStateEvent(roomId, type, stateKey): any {
+        return this.getRoom(roomId).getStateEvent(type, stateKey).content;
+    }
+
+    /**
+     * Mirrors the `MatrixClient` interface for getting the room state
+     * https://spec.matrix.org/latest/client-server-api/#get_matrixclientv3roomsroomidstate
+     * with the intention that it can be used as a transparent replacement.
+     * @param roomId The room to get the room state for.
+     * @returns All of the room state events in their entirity.
+     */
+    public getRoomState(roomId: string): any[] {
+        return this.getRoom(roomId).getRoomState();
+    }
+}


### PR DESCRIPTION
Add's the ability to start syncing with `full_state` and keep a cache of
all room state going forwards. This cache can then be used by the `MatrixClient`'s
`getRoomState` and `getRoomStateEvent` methods.

There is one slight problem. When using the RoomStateCache a MatrixClient will return `undefined` instead of a typical http client error with 404. I'm not sure what to do about that. 

For context I'm making this PR because we want to use this in Mjolnir. 