### PR TITLE
setPresenceStatus: status_msg defaults to undefined

### DIFF
--- a/src/MatrixClient.ts
+++ b/src/MatrixClient.ts
@@ -375,7 +375,7 @@ export class MatrixClient extends EventEmitter {
      * @returns {Promise<any>} Resolves when complete.
      */
     @timedMatrixClientFunctionCall()
-    public async setPresenceStatus(presence: "online" | "offline" | "unavailable", statusMessage: string | undefined): Promise<any> {
+    public async setPresenceStatus(presence: "online" | "offline" | "unavailable", statusMessage: string | undefined = undefined): Promise<any> {
         return this.doRequest("PUT", "/_matrix/client/r0/presence/" + encodeURIComponent(await this.getUserId()) + "/status", null, {
             presence: presence,
             status_msg: statusMessage,

--- a/src/MatrixClient.ts
+++ b/src/MatrixClient.ts
@@ -371,11 +371,11 @@ export class MatrixClient extends EventEmitter {
     /**
      * Sets the presence status for the current user.
      * @param {"online"|"offline"|"unavailable"} presence The new presence state for the user.
-     * @param {string} statusMessage Optional status message to include with the presence.
+     * @param {string?} statusMessage Optional status message to include with the presence.
      * @returns {Promise<any>} Resolves when complete.
      */
     @timedMatrixClientFunctionCall()
-    public async setPresenceStatus(presence: "online" | "offline" | "unavailable", statusMessage: string = null): Promise<any> {
+    public async setPresenceStatus(presence: "online" | "offline" | "unavailable", statusMessage: string | undefined): Promise<any> {
         return this.doRequest("PUT", "/_matrix/client/r0/presence/" + encodeURIComponent(await this.getUserId()) + "/status", null, {
             presence: presence,
             status_msg: statusMessage,

--- a/test/MatrixClientTest.ts
+++ b/test/MatrixClientTest.ts
@@ -518,6 +518,27 @@ describe('MatrixClient', () => {
             http.flushAllExpected();
             await client.setPresenceStatus(presence, message);
         });
+
+        it('should not send status_msg if the parameter is omitted', async () => {
+            const {client, http, hsUrl} = createTestClient();
+
+            const userId = "@test:example.org";
+            const presence = "online";
+
+            client.getUserId = () => Promise.resolve(userId);
+
+            // noinspection TypeScriptValidateJSTypes
+            http.when("PUT", "/_matrix/client/r0/presence").respond(200, (path, obj) => {
+                expect(path).toEqual(`${hsUrl}/_matrix/client/r0/presence/${encodeURIComponent(userId)}/status`);
+                expect(obj).toMatchObject({
+                    presence: presence,
+                });
+                return {};
+            });
+
+            http.flushAllExpected();
+            await client.setPresenceStatus(presence);
+        });
     });
 
     describe('getRoomAccountData', () => {

--- a/test/MatrixClientTest.ts
+++ b/test/MatrixClientTest.ts
@@ -530,7 +530,7 @@ describe('MatrixClient', () => {
             // noinspection TypeScriptValidateJSTypes
             http.when("PUT", "/_matrix/client/r0/presence").respond(200, (path, obj) => {
                 expect(path).toEqual(`${hsUrl}/_matrix/client/r0/presence/${encodeURIComponent(userId)}/status`);
-                expect(obj).toMatchObject({
+                expect(obj).toEqual({
                     presence: presence,
                 });
                 return {};


### PR DESCRIPTION
Fixes https://github.com/turt2live/matrix-bot-sdk/issues/79
Fixes https://github.com/matrix-org/matrix-appservice-discord/issues/591

Correct according to Matrix Spec 1.2: https://spec.matrix.org/v1.2/client-server-api/#put_matrixclientv3presenceuseridstatus

Sidenote: On the Matrix Spec the type of `msg_type`'s type is `[string null]` for the HTTP GET method. Maybe that's were the confusion came from.
https://spec.matrix.org/v1.2/client-server-api/#get_matrixclientv3presenceuseridstatus