### PR TITLE
Run the build scripts when installing from source

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "matrix-bot-sdk",
-  "version": "develop",
+  "version": "0.0.0-develop.0",
   "description": "TypeScript/JavaScript SDK for Matrix bots and appservices",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "homepage": "https://github.com/turt2live/matrix-bot-sdk#readme",
   "scripts": {
-    "prepublishOnly": "yarn build",
+    "prepare": "npm run build",
     "docs": "jsdoc -c jsdoc.json -P package.json -u docs/tutorials",
     "build": "tsc --listEmittedFiles",
     "lint": "eslint \"{src,test,examples}/**/*.ts\"",


### PR DESCRIPTION
The goal of this is to be able to use this as a git dependency, e.g.

`package.json`
```json
{
  "dependencies": {
    "matrix-bot-sdk": "https://github.com/sandhose/matrix-bot-sdk.git#quenting/npm-prepare"
  }
}
```

This changes three things:

 - have the build step in the `prepare` script instead of the `prepublishOnly`
 - have that build step using `npm run` instead of `yarn` (to avoid the implicit dependency on yarn)
 - make the version field a valid server version instead of `develop` (else installation fails with `Invalid version: develop`)

## Checklist

* [ ] **N/A** Tests written for all new code 
* [ ] **N/A** Linter has been satisfied
* [x] Sign-off given on the changes (see CONTRIBUTING.md)
