### PR TITLE
Hide sensitive keys in appservice query parameters

### DIFF
--- a/src/appservice/Appservice.ts
+++ b/src/appservice/Appservice.ts
@@ -266,7 +266,7 @@ export class Appservice extends EventEmitter {
 
         this.app.use(express.json({ limit: Number.MAX_SAFE_INTEGER })); // disable limits, use a reverse proxy
         morgan.token('url-safe', (req: express.Request) =>
-            `${req.path}?${stringify(redactObjectForLogging(req.query))}`,
+            `${req.path}?${stringify(redactObjectForLogging(req.query ?? {}))}`,
         );
 
         this.app.use(morgan({


### PR DESCRIPTION
Currently the appservice logger logs the access tokens for requests. In an ideal world appservices would be using headers, but that would require a spec change. Let's just hide the access token in the logs for now.
