### PR TITLE
Track users when joining encrypted rooms

### DIFF
--- a/src/e2ee/CryptoClient.ts
+++ b/src/e2ee/CryptoClient.ts
@@ -122,6 +122,8 @@ export class CryptoClient {
      * @param roomId The room ID.
      */
     public async onRoomJoin(roomId: string) {
+        const members = await this.client.getRoomMembers(roomId, null, ['join', 'invite']);
+        await this.engine.addTrackedUsers(members.map(e => e.membershipFor));
         await this.roomTracker.onRoomJoin(roomId);
     }
 

--- a/src/e2ee/CryptoClient.ts
+++ b/src/e2ee/CryptoClient.ts
@@ -122,9 +122,11 @@ export class CryptoClient {
      * @param roomId The room ID.
      */
     public async onRoomJoin(roomId: string) {
-        const members = await this.client.getRoomMembers(roomId, null, ['join', 'invite']);
-        await this.engine.addTrackedUsers(members.map(e => e.membershipFor));
         await this.roomTracker.onRoomJoin(roomId);
+        if (await this.isRoomEncrypted(roomId)) {
+            const members = await this.client.getRoomMembers(roomId, null, ['join', 'invite']);
+            await this.engine.addTrackedUsers(members.map(e => e.membershipFor));
+        }
     }
 
     /**


### PR DESCRIPTION
Users are only tracked when the bot user is already in the room when encryption is enabled or if the member status of the user changes in an already encrypted room.
This leads to megolm sessions which don't include all devices when a bot joins an encrypted room and existing users can't decrypt messages by the bot.

Before this change, only in rooms created by the bot could all other users decrypt messages from the bot.
Now already present users will also be tracked and receive the session keys.

A simple appservice reproducing the error, which is based on the `encryption_appservice.ts` example, can be found here (also contains docker-compose file for synapse and co):
https://github.com/B4dM4n/hookkshot-e2ee-test/blob/main/enctest/src/index.ts

Steps to reproduce:
- Invite `@encbot:local` to encrypted DM/room (inviting user is not tracked by the bot)
- Send `!ping` to bot -> unable to decrypt error
- Send `!invite` to bot and join room (invited user is now tracked)
- Send `!ping` to room -> `Pong` can be decrypted

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

* [ ] Tests written for all new code
* [ ] Linter has been satisfied - No idea how to check
* [x] Sign-off given on the changes (see CONTRIBUTING.md)
