### PR TITLE
Follow Matrix spec for MatrixClient.getRoomMembers arguments

### DIFF
--- a/src/MatrixClient.ts
+++ b/src/MatrixClient.ts
@@ -1079,11 +1079,47 @@ export class MatrixClient extends EventEmitter {
      * arguments. To change the point in time, use the batchToken.
      * @param {string} roomId The room ID to get members in.
      * @param {string} batchToken The point in time to get members at (or null for 'now')
+     * @param {Membership} membership The membership kind to search for.
+     * @param {Membership} notMembership The membership kind to not search for.
+     * @returns {Promise<MembershipEvent[]>} Resolves to the membership events of the users in the room.
+     */
+    public getRoomMembers(
+        roomId: string,
+        batchToken?: string,
+        membership?: Membership,
+        notMembership?: Membership,
+    ): Promise<MembershipEvent[]>;
+
+    /**
+     * Gets the membership events of users in the room. Defaults to all membership
+     * types, though this can be controlled with the membership and notMembership
+     * arguments. To change the point in time, use the batchToken.
+     * @param {string} roomId The room ID to get members in.
+     * @param {string} batchToken The point in time to get members at (or null for 'now')
      * @param {string[]} membership The membership kinds to search for.
      * @param {string[]} notMembership The membership kinds to not search for.
-     * @returns {Promise<any[]>} Resolves to the membership events of the users in the room.
+     * @returns {Promise<MembershipEvent[]>} Resolves to the membership events of the users in the room.
+     * @deprecated The method should not be used, because the Matrix API doesn't allow to filter for multiple membership kinds.
      */
-    public getRoomMembers(roomId: string, batchToken: string = null, membership: Membership[] = null, notMembership: Membership[] = null): Promise<MembershipEvent[]> {
+    public getRoomMembers(
+        roomId: string,
+        batchToken?: string,
+        membership?: Membership[],
+        notMembership?: Membership[],
+    ): Promise<MembershipEvent[]>;
+
+    public getRoomMembers(
+        roomId: string,
+        batchToken?: string,
+        membership?: Membership | Membership[],
+        notMembership?: Membership | Membership[],
+    ): Promise<MembershipEvent[]> {
+        if (membership?.length > 1) {
+            LogService.warn("MatrixClientLite", "getRoomMembers called with multiple membership kinds.");
+        }
+        if (notMembership?.length > 1) {
+            LogService.warn("MatrixClientLite", "getRoomMembers called with multiple notMembership kinds.");
+        }
         const qs = {};
         if (batchToken) qs["at"] = batchToken;
         if (membership) qs["membership"] = membership;

--- a/src/e2ee/CryptoClient.ts
+++ b/src/e2ee/CryptoClient.ts
@@ -111,7 +111,7 @@ export class CryptoClient {
             if (membership.effectiveMembership !== 'join' && membership.effectiveMembership !== 'invite') return;
             await this.engine.addTrackedUsers([membership.membershipFor]);
         } else if (event['type'] === 'm.room.encryption') {
-            const members = await this.client.getRoomMembers(roomId, null, ['join', 'invite']);
+            const members = await this.client.getRoomMembers(roomId, null, null, 'leave');
             await this.engine.addTrackedUsers(members.map(e => e.membershipFor));
         }
     }

--- a/test/MatrixClientTest.ts
+++ b/test/MatrixClientTest.ts
@@ -3080,18 +3080,18 @@ describe('MatrixClient', () => {
                     },
                 },
             ];
-            const forMemberships: Membership[] = ['join', 'leave'];
-            const forNotMemberships: Membership[] = ['ban'];
+            const forMembership: Membership = 'join';
+            const forNotMembership: Membership = 'ban';
 
             // noinspection TypeScriptValidateJSTypes
             http.when("GET", "/_matrix/client/v3/rooms").respond(200, (path, content, req) => {
                 expect(path).toEqual(`${hsUrl}/_matrix/client/v3/rooms/${encodeURIComponent(roomId)}/members`);
-                expectArrayEquals(forMemberships, (req.queryParams as any).membership);
-                expectArrayEquals(forNotMemberships, (req.queryParams as any).not_membership);
+                expect(forMembership).toEqual((req.queryParams as any).membership);
+                expect(forNotMembership).toEqual((req.queryParams as any).not_membership);
                 return { chunk: memberEvents };
             });
 
-            const [result] = await Promise.all([client.getRoomMembers(roomId, null, forMemberships, forNotMemberships), http.flushAllExpected()]);
+            const [result] = await Promise.all([client.getRoomMembers(roomId, null, forMembership, forNotMembership), http.flushAllExpected()]);
             expect(result).toBeDefined();
             expect(result.length).toBe(2);
             expect(result[0].membership).toBe(memberEvents[0]['content']['membership']);

--- a/test/encryption/CryptoClientTest.ts
+++ b/test/encryption/CryptoClientTest.ts
@@ -529,10 +529,10 @@ describe('CryptoClient', () => {
 
             const roomId = "!room:example.org";
             const prom2 = new Promise<void>(extResolve => {
-                client.getRoomMembers = simple.mock().callFn((rid, token, memberships) => {
+                client.getRoomMembers = simple.mock().callFn((rid, token, _membership, notMembership) => {
                     expect(rid).toEqual(roomId);
                     expect(token).toBeFalsy();
-                    expect(memberships).toEqual(["join", "invite"]);
+                    expect(notMembership).toEqual("leave");
                     extResolve();
                     return Promise.resolve(targetUserIds.map(u => new MembershipEvent({
                         type: "m.room.member",


### PR DESCRIPTION
The `MatrixClient.getRoomMembers` arguments allow to specify multiple membership kind filters, wich are passed to the Matrix server as repeated query arguments to the `/rooms/{roomId}/members` API.
The [spec](https://spec.matrix.org/unstable/client-server-api/#get_matrixclientv3roomsroomidmembers) defines the `membership` and `not_membership` arguments as an enum, which can not be repeated.

This is also how Synapse implements this API, by only using the first occurrence of each parameter and ignoring the rest:

```shell
$ # Lists all members
$ curl -sS 'http://localhost:8008/_matrix/client/r0/rooms/!FbdTKTZKWpCPuOTyyt:local/members' -H 'Authorization: Bearer <token>' | jq
{
  "chunk": [
    {
      "type": "m.room.member",
      "room_id": "!FbdTKTZKWpCPuOTyyt:local",
      "sender": "@admin:local",
      "content": {
        "membership": "join",
        "displayname": "admin"
      },
      "state_key": "@admin:local",
      "origin_server_ts": 1659696716579,
      "unsigned": {
        "age": 101233
      },
      "event_id": "$ivix5q0enY6NbdWh1k1eQ6misoEJ8rzgqUgLpKOIVbg",
      "user_id": "@admin:local",
      "age": 101233
    },
    {
      "type": "m.room.member",
      "room_id": "!FbdTKTZKWpCPuOTyyt:local",
      "sender": "@admin:local",
      "content": {
        "membership": "invite",
        "displayname": "test"
      },
      "state_key": "@test:local",
      "origin_server_ts": 1659696724300,
      "unsigned": {
        "age": 93512
      },
      "event_id": "$qvpBNoB609YtOKPVqV3n8LY_Oubh8LM-lufxwhXS8YU",
      "user_id": "@admin:local",
      "age": 93512
    }
  ]
}
```

```shell
$ # Only lists joined and ignores invited members
$ curl -sS 'http://localhost:8008/_matrix/client/r0/rooms/!FbdTKTZKWpCPuOTyyt:local/members?membership=join&membership=invite' -H 'Authorization: Bearer <token>' | jq
{
  "chunk": [
    {
      "type": "m.room.member",
      "room_id": "!FbdTKTZKWpCPuOTyyt:local",
      "sender": "@admin:local",
      "content": {
        "membership": "join",
        "displayname": "admin"
      },
      "state_key": "@admin:local",
      "origin_server_ts": 1659696716579,
      "unsigned": {
        "age": 106183
      },
      "event_id": "$ivix5q0enY6NbdWh1k1eQ6misoEJ8rzgqUgLpKOIVbg",
      "user_id": "@admin:local",
      "age": 106183
    }
  ]
}
```

```shell
$ # Lists joined members as expected
$ curl -sS 'http://localhost:8008/_matrix/client/r0/rooms/!FbdTKTZKWpCPuOTyyt:local/members?membership=join' -H 'Authorization: Bearer <token>' | jq
{
  "chunk": [
    {
      "type": "m.room.member",
      "room_id": "!FbdTKTZKWpCPuOTyyt:local",
      "sender": "@admin:local",
      "content": {
        "membership": "join",
        "displayname": "admin"
      },
      "state_key": "@admin:local",
      "origin_server_ts": 1659696716579,
      "unsigned": {
        "age": 113113
      },
      "event_id": "$ivix5q0enY6NbdWh1k1eQ6misoEJ8rzgqUgLpKOIVbg",
      "user_id": "@admin:local",
      "age": 113113
    }
  ]
}
```

```shell
$ # Lists invited members as expected
$ curl -sS 'http://localhost:8008/_matrix/client/r0/rooms/!FbdTKTZKWpCPuOTyyt:local/members?membership=invite' -H 'Authorization: Bearer <token>' | jq
{
  "chunk": [
    {
      "type": "m.room.member",
      "room_id": "!FbdTKTZKWpCPuOTyyt:local",
      "sender": "@admin:local",
      "content": {
        "membership": "invite",
        "displayname": "test"
      },
      "state_key": "@test:local",
      "origin_server_ts": 1659696724300,
      "unsigned": {
        "age": 110940
      },
      "event_id": "$qvpBNoB609YtOKPVqV3n8LY_Oubh8LM-lufxwhXS8YU",
      "user_id": "@admin:local",
      "age": 110940
    }
  ]
}
```

This PR uses [function overloads](https://www.typescriptlang.org/docs/handbook/2/functions.html#function-overloads) to deprecate the original function signature and adds a new signature with single membership kind arguments.

## Checklist

* [ ] Tests written for all new code
* [x] Linter has been satisfied
* [x] Sign-off given on the changes (see CONTRIBUTING.md)
