### PR TITLE
Remove default from MatrixError

### DIFF
--- a/src/SynapseAdminApis.ts
+++ b/src/SynapseAdminApis.ts
@@ -1,5 +1,5 @@
 import { MatrixClient } from "./MatrixClient";
-import MatrixError from "./models/MatrixError";
+import { MatrixError } from "./models/MatrixError";
 
 /**
  * Information about a user on Synapse.

--- a/src/appservice/Intent.ts
+++ b/src/appservice/Intent.ts
@@ -12,7 +12,7 @@ import { Appservice, IAppserviceOptions } from "./Appservice";
 // noinspection TypeScriptPreferShortImport
 import { timedIntentFunctionCall } from "../metrics/decorators";
 import { UnstableAppserviceApis } from "./UnstableAppserviceApis";
-import MatrixError from "../models/MatrixError";
+import { MatrixError } from "../models/MatrixError";
 
 /**
  * An Intent is an intelligent client that tracks things like the user's membership

--- a/src/http.ts
+++ b/src/http.ts
@@ -1,6 +1,6 @@
 import { LogLevel, LogService } from "./logging/LogService";
 import { getRequestFn } from "./request";
-import MatrixError from './models/MatrixError';
+import { MatrixError } from "./models/MatrixError";
 
 let lastRequestId = 0;
 

--- a/src/logging/LogService.ts
+++ b/src/logging/LogService.ts
@@ -1,4 +1,4 @@
-import MatrixError from "../models/MatrixError";
+import { MatrixError } from "../models/MatrixError";
 import { ConsoleLogger } from "./ConsoleLogger";
 import { ILogger } from "./ILogger";
 

--- a/src/models/MatrixError.ts
+++ b/src/models/MatrixError.ts
@@ -2,7 +2,7 @@
  * Represents an HTTP error from the Matrix server.
  * @category Error handling
  */
-export default class MatrixError extends Error {
+export class MatrixError extends Error {
     /**
      * The Matrix error code
      */


### PR DESCRIPTION
I made the mistake of making this class a default, which means that when it was exported it would not be a named class and therefore be unimportable. We've worked around this in some projects by directly depending on `MatrixError.ts` file, but that's a sucky way to do it.

This PR changes the class to be a regular exported class, and changes all internal references to match. This *will* break projects that depended on the class being a default, but arguably that's not supported behavior. It's also trivial to go and fix your imports on the next update.

## Checklist

* [N/A - types change] Tests written for all new code ()
* [x] Linter has been satisfied
* [x] Sign-off given on the changes (see CONTRIBUTING.md)

Signed-off-by: Will Hunt <signoff@half-shot.uk>
