### PR TITLE
Add `forgetRoom`

### DIFF
--- a/src/MatrixClient.ts
+++ b/src/MatrixClient.ts
@@ -1171,10 +1171,10 @@ export class MatrixClient extends EventEmitter {
     /**
      * Forgets the given room
      * @param {string} roomId the room ID to forget
-     * @returns {Promise<any>} resolves when forgotten
+     * @returns {Promise<{}>} Resolves when forgotten
      */
     @timedMatrixClientFunctionCall()
-    public forgetRoom(roomId: string): Promise<any> {
+    public forgetRoom(roomId: string): Promise<{}> {
         return this.doRequest("POST", "/_matrix/client/v3/rooms/" + encodeURIComponent(roomId) + "/forget");
     }
 

--- a/src/MatrixClient.ts
+++ b/src/MatrixClient.ts
@@ -1169,6 +1169,16 @@ export class MatrixClient extends EventEmitter {
     }
 
     /**
+     * Forgets the given room
+     * @param {string} roomId the room ID to forget
+     * @returns {Promise<any>} resolves when forgotten
+     */
+    @timedMatrixClientFunctionCall()
+    public forgetRoom(roomId: string): Promise<any> {
+        return this.doRequest("POST", "/_matrix/client/v3/rooms/" + encodeURIComponent(roomId) + "/forget");
+    }
+
+    /**
      * Sends a read receipt for an event in a room
      * @param {string} roomId the room ID to send the receipt to
      * @param {string} eventId the event ID to set the receipt at

--- a/test/MatrixClientTest.ts
+++ b/test/MatrixClientTest.ts
@@ -3342,6 +3342,22 @@ describe('MatrixClient', () => {
         });
     });
 
+    describe('forgetRoom', () => {
+        it('should call the right endpoint', async () => {
+            const { client, http, hsUrl } = createTestClient();
+
+            const roomId = "!testing:example.org";
+
+            // noinspection TypeScriptValidateJSTypes
+            http.when("POST", "/_matrix/client/v3/rooms").respond(200, (path) => {
+                expect(path).toEqual(`${hsUrl}/_matrix/client/v3/rooms/${encodeURIComponent(roomId)}/forget`);
+                return {};
+            });
+
+            await Promise.all([client.forgetRoom(roomId), http.flushAllExpected()]);
+        });
+    });
+
     describe('sendReadReceipt', () => {
         it('should call the right endpoint', async () => {
             const { client, http, hsUrl } = createTestClient();


### PR DESCRIPTION
This adds client support for the [`rooms/{roomId}/forget`](https://spec.matrix.org/v1.3/client-server-api/#post_matrixclientv3roomsroomidforget) API call, which is useful for making rooms eligible for deletion.

## Checklist

* [x] Tests written for all new code
* [x] Linter has been satisfied
* [x] Sign-off given on the changes (see CONTRIBUTING.md)
