### PR TITLE
Update presence types & documentation

### DIFF
--- a/src/MatrixClient.ts
+++ b/src/MatrixClient.ts
@@ -43,6 +43,7 @@ import { RustSdkCryptoStorageProvider } from "./storage/RustSdkCryptoStorageProv
 import { DMs } from "./DMs";
 import { ServerVersions } from "./models/ServerVersions";
 import { RoomCreateOptions } from "./models/CreateRoom";
+import { PresenceState } from './models/events/PresenceEvent';
 
 const SYNC_BACKOFF_MIN_MS = 5000;
 const SYNC_BACKOFF_MAX_MS = 15000;
@@ -59,7 +60,7 @@ export class MatrixClient extends EventEmitter {
      *
      * Has no effect if the client is not syncing. Does not apply until the next sync request.
      */
-    public syncingPresence: "online" | "offline" | "unavailable" | null = null;
+    public syncingPresence: PresenceState | null = null;
 
     /**
      * The number of milliseconds to wait for new events for on the next sync.
@@ -427,12 +428,12 @@ export class MatrixClient extends EventEmitter {
 
     /**
      * Sets the presence status for the current user.
-     * @param {"online"|"offline"|"unavailable"} presence The new presence state for the user.
+     * @param {PresenceState} presence The new presence state for the user.
      * @param {string?} statusMessage Optional status message to include with the presence.
      * @returns {Promise<any>} Resolves when complete.
      */
     @timedMatrixClientFunctionCall()
-    public async setPresenceStatus(presence: "online" | "offline" | "unavailable", statusMessage: string | undefined = undefined): Promise<any> {
+    public async setPresenceStatus(presence: PresenceState, statusMessage: string | undefined = undefined): Promise<any> {
         return this.doRequest("PUT", "/_matrix/client/v3/presence/" + encodeURIComponent(await this.getUserId()) + "/status", null, {
             presence: presence,
             status_msg: statusMessage,

--- a/src/models/events/PresenceEvent.ts
+++ b/src/models/events/PresenceEvent.ts
@@ -1,7 +1,12 @@
 import { MatrixEvent } from "./Event";
 
 /**
- * The allowed states of presence in Matrix
+ * The allowed states of presence in Matrix.
+ *
+ * * `online`: The default state when the user is connected to an event stream.
+ * * `unavailable`: The user is not reachable at this time e.g. they are idle.
+ * * `offline`: The user is not connected to an event stream or is explicitly suppressing their profile information from being sent.
+ *
  * @category Matrix event info
  * @see PresenceEventContent
  */
@@ -30,6 +35,8 @@ export interface PresenceEventContent {
 
     /**
      * The user's presence state.
+     *
+     * @see {@link PresenceState} for a description of each presence key.
      */
     presence: PresenceState;
 


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

* [x] Tests written for all new code
* [x] Linter has been satisfied
* [x] Sign-off given on the changes (see CONTRIBUTING.md)

While working on a PR for matrix-appservice-discord, I was tripped up by the presence states.
I usually only look in the JSDocs for information while working on projects/PRs, and the term **unavailable** wasn't clearly defined or linked to before.

Looked to me that `"unavailable"` was either:
* Home server has presence disabled, so the presence is unavailable.
* DND

I had to ask in chat to find out it was actually neither of those things. ^-^'

Maybe for convenience for myself and others, could we just add a link to the spec that clearly defines these?