### PR TITLE
docs: fix typos in jsdocs

### DIFF
--- a/src/MatrixClient.ts
+++ b/src/MatrixClient.ts
@@ -1959,8 +1959,8 @@ export class MatrixClient extends EventEmitter {
     /**
      * Get relations for a given event.
      * @param {string} roomId The room ID to for the given event.
-     * @param {string} eventId The event ID to list reacations for.
-     * @param {string?} relationType The type of reaction (e.g. `m.room.member`) to filter for. Optional.
+     * @param {string} eventId The event ID to list relations for.
+     * @param {string?} relationType The type of relations (e.g. `m.room.member`) to filter for. Optional.
      * @param {string?} eventType The type of event to look for (e.g. `m.room.member`). Optional.
      * @returns {Promise<{chunk: any[]}>} Resolves to an object containing the chunk of relations
      */

--- a/src/UnstableApis.ts
+++ b/src/UnstableApis.ts
@@ -40,8 +40,8 @@ export class UnstableApis {
     /**
      * Get relations for a given event.
      * @param {string} roomId The room ID to for the given event.
-     * @param {string} eventId The event ID to list reacations for.
-     * @param {string?} relationType The type of reaction (e.g. `m.room.member`) to filter for. Optional.
+     * @param {string} eventId The event ID to list relations for.
+     * @param {string?} relationType The type of relations (e.g. `m.room.member`) to filter for. Optional.
      * @param {string?} eventType The type of event to look for (e.g. `m.room.member`). Optional.
      * @returns {Promise<{chunk: any[]}>} Resolves to an object containing the chunk of relations
      * @deprecated Please use the function of the same name in MatrixClient. This will be removed in a future release.


### PR DESCRIPTION
Signed-off-by: Seth Falco <seth@falco.fun>

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

* [x] Tests written for all new code
* [x] Linter has been satisfied
* [x] Sign-off given on the changes (see CONTRIBUTING.md)

---

Sorry, another minor JSDoc change! I assume both of those are meant to say "relations".

Ran into this while working on:
* https://github.com/matrix-org/matrix-appservice-discord/pull/862

--- 

I didn't change anything now, but on the side, I think noting that arguments are optional in the JSDocs is redundant. We can see that from the typings already. 🤔
 
Any thoughts on removing that?