### PR TITLE
Query & claim needed keys before encrypting

### DIFF
--- a/src/e2ee/RustEngine.ts
+++ b/src/e2ee/RustEngine.ts
@@ -111,8 +111,8 @@ export class RustEngine {
         settings.rotationPeriod = BigInt(encEv.rotationPeriodMs);
         settings.rotationPeriodMessages = BigInt(encEv.rotationPeriodMessages);
 
-        await this.run(RequestType.KeysQuery);
         await this.lock.acquire(SYNC_LOCK_NAME, async () => {
+            await this.runOnly(RequestType.KeysQuery);
             const keysClaim = await this.machine.getMissingSessions(members);
             if (keysClaim) {
                 await this.processKeysClaimRequest(keysClaim);

--- a/src/e2ee/RustEngine.ts
+++ b/src/e2ee/RustEngine.ts
@@ -32,7 +32,11 @@ export class RustEngine {
     public constructor(public readonly machine: OlmMachine, private client: MatrixClient) {
     }
 
-    public async run(...types: RequestType[]) {
+    public async run() {
+        await this.runOnly(); // run everything, but with syntactic sugar
+    }
+
+    private async runOnly(...types: RequestType[]) {
         // Note: we should not be running this until it runs out, so cache the value into a variable
         const requests = await this.machine.outgoingRequests();
         for (const request of requests) {


### PR DESCRIPTION
Ensure that the bot has all keys needed for sharing a room key with recipients before encryping an event in that room.

Signed-off-by: Andrew Ferrazzutti <andrewf@element.io>

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

* [ ] Tests written for all new code
* [x] Linter has been satisfied
* [x] Sign-off given on the changes (see CONTRIBUTING.md)
