### PR TITLE
Use main appservice client for MSC2778 /login

### DIFF
--- a/src/appservice/Intent.ts
+++ b/src/appservice/Intent.ts
@@ -153,8 +153,7 @@ export class Intent {
                                     user: this.userId,
                                 },
                             };
-                            this.client.impersonateUserId(null); // avoid confusing homeserver
-                            const res = await this.client.doRequest("POST", "/_matrix/client/v3/login", {}, loginBody);
+                            const res = await this.appservice.botClient.doRequest("POST", "/_matrix/client/v3/login", {}, loginBody);
                             this.makeClient(true, res['access_token']);
                             storage.storeValue("accessToken", this.client.accessToken);
                             prepared = true;


### PR DESCRIPTION
If the /login call is made by a namespaced bot's client that had its impersonated user ID temporarily cleared, there is a risk of that client being used in another asynchronous call where its impersonated user ID is looked up before it has been restored.

Using the main appservice client for the /login call instead achieves the full effect of the call without needing to tweak any properties.

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

* [ ] Tests written for all new code
* [x] Linter has been satisfied
* [x] Sign-off given on the changes (see CONTRIBUTING.md)
