### PR TITLE
Update to matrix-sdk-crypto-nodejs@0.1.0-beta.3 to support Node 19

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "tsconfig.json"
   ],
   "dependencies": {
-    "@matrix-org/matrix-sdk-crypto-nodejs": "^0.1.0-beta.2",
+    "@matrix-org/matrix-sdk-crypto-nodejs": "^0.1.0-beta.3",
     "@types/express": "^4.17.13",
     "another-json": "^0.2.0",
     "async-lock": "^1.3.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -584,10 +584,10 @@
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
 
-"@matrix-org/matrix-sdk-crypto-nodejs@^0.1.0-beta.2":
-  version "0.1.0-beta.2"
-  resolved "https://registry.yarnpkg.com/@matrix-org/matrix-sdk-crypto-nodejs/-/matrix-sdk-crypto-nodejs-0.1.0-beta.2.tgz#5e0308fe49eaddcfb68130ae623d24edf9f9e807"
-  integrity sha512-0wyNXE4tuCxXqxuaAEBxzKuf0Slmyk8rU42/yDJqR9yLeuG/50sPJOXOZcXba4SN3RJgaqtQBzJxg6y25iKG7A==
+"@matrix-org/matrix-sdk-crypto-nodejs@^0.1.0-beta.3":
+  version "0.1.0-beta.3"
+  resolved "https://registry.yarnpkg.com/@matrix-org/matrix-sdk-crypto-nodejs/-/matrix-sdk-crypto-nodejs-0.1.0-beta.3.tgz#a07225dd180d9d227c24ba62bba439939446d113"
+  integrity sha512-jHFn6xBeNqfsY5gX60akbss7iFBHZwXycJWMw58Mjz08OwOi7AbTxeS9I2Pa4jX9/M2iinskmGZbzpqOT2fM3A==
   dependencies:
     node-downloader-helper "^2.1.1"
 


### PR DESCRIPTION
This version fixes a bug that would have prevented the rust binary's from being downloaded successfully on Node 19.