### PR TITLE
Refresh joined rooms when enabling crypto

### DIFF
--- a/src/appservice/Intent.ts
+++ b/src/appservice/Intent.ts
@@ -168,9 +168,8 @@ export class Intent {
                     }
 
                     // Now set up crypto
-                    await this.client.crypto.prepare(await this.client.getJoinedRooms());
+                    await this.client.crypto.prepare(await this.refreshJoinedRooms());
 
-                    await this.refreshJoinedRooms();
                     this.appservice.on("room.event", (roomId, event) => {
                         if (!this.knownJoinedRooms.includes(roomId)) return;
                         this.client.crypto.onRoomEvent(roomId, event);

--- a/src/appservice/Intent.ts
+++ b/src/appservice/Intent.ts
@@ -170,6 +170,7 @@ export class Intent {
                     // Now set up crypto
                     await this.client.crypto.prepare(await this.client.getJoinedRooms());
 
+                    await this.refreshJoinedRooms();
                     this.appservice.on("room.event", (roomId, event) => {
                         if (!this.knownJoinedRooms.includes(roomId)) return;
                         this.client.crypto.onRoomEvent(roomId, event);


### PR DESCRIPTION
When enabling crypto on an Intent, refresh its list of joined rooms, as it's used to determine which rooms to watch for crypto updates.

This fixes an issue where a restart would cause Intents to lose track of which rooms they were joined to, unless the list is refreshed either manually or in response to a membership event.

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

* [ ] Tests written for all new code
* [x] Linter has been satisfied
* [x] Sign-off given on the changes (see CONTRIBUTING.md)
