### PR TITLE
Send to-device event list, not wrapper, to engine

### DIFF
--- a/src/e2ee/CryptoClient.ts
+++ b/src/e2ee/CryptoClient.ts
@@ -142,7 +142,7 @@ export class CryptoClient {
 
     /**
      * Updates the client's sync-related data.
-     * @param {IToDeviceMessage<IOlmEncrypted>} toDeviceMessages The to-device messages received.
+     * @param {IToDeviceMessage<IOlmEncrypted>[]} toDeviceMessages The to-device messages received.
      * @param {OTKCounts} otkCounts The current OTK counts.
      * @param {OTKAlgorithm[]} unusedFallbackKeyAlgs The unused fallback key algorithms.
      * @param {string[]} changedDeviceLists The user IDs which had device list changes.
@@ -157,7 +157,7 @@ export class CryptoClient {
         changedDeviceLists: string[],
         leftDeviceLists: string[],
     ): Promise<void> {
-        const deviceMessages = JSON.stringify({ events: toDeviceMessages });
+        const deviceMessages = JSON.stringify(toDeviceMessages);
         const deviceLists = new DeviceLists(
             changedDeviceLists.map(u => new UserId(u)),
             leftDeviceLists.map(u => new UserId(u)));

--- a/src/e2ee/CryptoClient.ts
+++ b/src/e2ee/CryptoClient.ts
@@ -142,7 +142,7 @@ export class CryptoClient {
 
     /**
      * Updates the client's sync-related data.
-     * @param {IToDeviceMessage<IOlmEncrypted>[]} toDeviceMessages The to-device messages received.
+     * @param {Array.<IToDeviceMessage<IOlmEncrypted>>} toDeviceMessages The to-device messages received.
      * @param {OTKCounts} otkCounts The current OTK counts.
      * @param {OTKAlgorithm[]} unusedFallbackKeyAlgs The unused fallback key algorithms.
      * @param {string[]} changedDeviceLists The user IDs which had device list changes.


### PR DESCRIPTION
As of matrix-org/matrix-rust-sdk@a443e7277, the JSON-encoded `toDeviceEvents` passed to OlmMachine.receiveSyncChanges must be the list of events themselves, instead of a wrapper object that contains the event list.

Signed-off-by: Andrew Ferrazzutti <andrewf@element.io>

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

* [ ] Tests written for all new code
* [x] Linter has been satisfied
* [x] Sign-off given on the changes (see CONTRIBUTING.md)

---

This fixes the mysterious crypto error of `invalid type: map, expected a sequence` that started happening after updating to `beta.3` of the Rust SDK.

The reason behind the crash is that `CryptoClient.updateSyncData` was sending a JSON-encoded wrapper object around a list of to-devices message, which has the form `{"events":[...]}`.  This used to be valid, but matrix-org/matrix-rust-sdk@a443e7277 changed the expected format to just the event list, instead of an object containing the list.  An example of the new format in use can be found in [`tests/machine.test.js`](https://github.com/matrix-org/matrix-rust-sdk/blob/matrix-sdk-crypto-nodejs-v0.1.0-beta.3/bindings/matrix-sdk-crypto-nodejs/tests/machine.test.js#L54).

This fixes crashes for both bots & appservices, as [even the latter calls `CryptoClient.updateSyncData`](https://github.com/turt2live/matrix-bot-sdk/blob/main/src/appservice/Appservice.ts#L791) despite "sync-ish" things typically being used only by bots.

Note that bots may still crash in `CryptoClient.updateSyncData` without https://github.com/turt2live/matrix-bot-sdk/pull/272.