### PR TITLE
Expect to-device event list, not wrapper

### DIFF
--- a/src/e2ee/CryptoClient.ts
+++ b/src/e2ee/CryptoClient.ts
@@ -165,8 +165,8 @@ export class CryptoClient {
         await this.engine.lock.acquire(SYNC_LOCK_NAME, async () => {
             const syncResp = await this.engine.machine.receiveSyncChanges(deviceMessages, deviceLists, otkCounts, unusedFallbackKeyAlgs);
             const decryptedToDeviceMessages = JSON.parse(syncResp);
-            if (Array.isArray(decryptedToDeviceMessages?.events)) {
-                for (const msg of decryptedToDeviceMessages.events) {
+            if (Array.isArray(decryptedToDeviceMessages)) {
+                for (const msg of decryptedToDeviceMessages) {
                     this.client.emit("to_device.decrypted", msg);
                 }
             }


### PR DESCRIPTION
Decrypted device events are now received as an array, not an object containing a array as a property.

Signed-off-by: Andrew Ferrazzutti <andrewf@element.io>

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

* [ ] Tests written for all new code
* [x] Linter has been satisfied
* [x] Sign-off given on the changes (see CONTRIBUTING.md)

----

This is a follow-up of a4d9b037.