### PR TITLE
Always send reactions unencrypted

### DIFF
--- a/src/UnstableApis.ts
+++ b/src/UnstableApis.ts
@@ -28,7 +28,7 @@ export class UnstableApis {
      * @returns {Promise<string>} Resolves to the event ID of the reaction
      */
     public async addReactionToEvent(roomId: string, eventId: string, emoji: string): Promise<string> {
-        return this.client.sendEvent(roomId, "m.reaction", {
+        return this.client.sendRawEvent(roomId, "m.reaction", {
             "m.relates_to": {
                 event_id: eventId,
                 key: emoji,


### PR DESCRIPTION
Clients don't support encrypted reactions.

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

* [ ] Tests written for all new code
* [ ] Linter has been satisfied
* [ ] Sign-off given on the changes (see CONTRIBUTING.md)
