### PR TITLE
Start a sync after creating a new filter

### DIFF
--- a/src/MatrixClient.ts
+++ b/src/MatrixClient.ts
@@ -676,7 +676,7 @@ export class MatrixClient extends EventEmitter {
 
         if (createFilter && filter) {
             LogService.trace("MatrixClientLite", "Creating new filter");
-            return this.doRequest("POST", "/_matrix/client/v3/user/" + encodeURIComponent(userId) + "/filter", null, filter).then(async response => {
+            await this.doRequest("POST", "/_matrix/client/v3/user/" + encodeURIComponent(userId) + "/filter", null, filter).then(async response => {
                 this.filterId = response["filter_id"];
                 // noinspection ES6RedundantAwait
                 await Promise.resolve(this.storage.setSyncToken(null));

--- a/test/MatrixClientTest.ts
+++ b/test/MatrixClientTest.ts
@@ -1177,8 +1177,14 @@ describe('MatrixClient', () => {
             http.when("POST", "/_matrix/client/v3/user").respond(200, (path, content) => {
                 expect(path).toEqual(`${hsUrl}/_matrix/client/v3/user/${encodeURIComponent(userId)}/filter`);
                 expect(content).toMatchObject(filter);
-                client.stop(); // avoid a sync early
                 return { filter_id: filterId };
+            });
+
+            // noinspection TypeScriptValidateJSTypes
+            http.when("GET", "/_matrix/client/v3/sync").respond(200, (path, content, req) => {
+                expect(req.queryParams.filter).toBe(filterId);
+                client.stop();
+                return { next_batch: "123" };
             });
 
             await Promise.all([client.start(filter), http.flushAllExpected()]);
@@ -1215,8 +1221,14 @@ describe('MatrixClient', () => {
             http.when("POST", "/_matrix/client/v3/user").respond(200, (path, content) => {
                 expect(path).toEqual(`${hsUrl}/_matrix/client/v3/user/${encodeURIComponent(userId)}/filter`);
                 expect(content).toMatchObject(filter);
-                client.stop(); // avoid a sync early
                 return { filter_id: filterId };
+            });
+
+            // noinspection TypeScriptValidateJSTypes
+            http.when("GET", "/_matrix/client/v3/sync").respond(200, (path, content, req) => {
+                expect(req.queryParams.filter).toBe(filterId);
+                client.stop();
+                return { next_batch: "123" };
             });
 
             await Promise.all([client.start(filter), http.flushAllExpected()]);


### PR DESCRIPTION
When we provide a filter to the sync endpoint, the sync is never started if the filter needs to be created. If the filter already exists, everything starts correctly. Looks like a past refactoring broke it.

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

* [x] Tests written for all new code
* [x] Linter has been satisfied
* [x] Sign-off given on the changes (see CONTRIBUTING.md)
