### PR TITLE
Permalinks should be able to decode and encode via servers.

### DIFF
--- a/src/helpers/Permalinks.ts
+++ b/src/helpers/Permalinks.ts
@@ -38,7 +38,7 @@ export class Permalinks {
     private static encodeViaArgs(servers: string[]): string {
         if (!servers || !servers.length) return "";
 
-        return `?via=${servers.join("via=")}`;
+        return `?via=${servers.join("&via=")}`;
     }
 
     /**
@@ -77,32 +77,22 @@ export class Permalinks {
      * @returns {PermalinkParts} The parts of the permalink.
      */
     public static parseUrl(matrixTo: string): PermalinkParts {
-        if (!matrixTo || !matrixTo.startsWith("https://matrix.to/#/")) {
-            throw new Error("Not a valid matrix.to URL");
-        }
-
-        const parts = matrixTo.substring("https://matrix.to/#/".length).split("/");
-
-        const entity = decodeURIComponent(parts[0]);
-        if (entity[0] === '@') {
+        const matrixToRegexp = /https:\/\/matrix.to\/#\/(?<entity>[!#@][^/?]+)\/?(?<eventId>\$[^/?]+)?\/?(?<query>\?.+)?$/;
+        const [match, entity, eventId, queryParameters] = matrixToRegexp.exec(matrixTo) ?? Array(4);
+        if (match === undefined || entity === undefined) {
+            throw new Error("Unexpected entity");
+        } else if (entity[0] === '@') {
             return { userId: entity, roomIdOrAlias: undefined, eventId: undefined, viaServers: undefined };
         } else if (entity[0] === '#' || entity[0] === '!') {
-            if (parts.length === 1) {
-                return { roomIdOrAlias: entity, userId: undefined, eventId: undefined, viaServers: [] };
-            }
-
-            // rejoin the rest because v3 room can have slashes
-            const eventIdAndQuery = decodeURIComponent(parts.length > 1 ? parts.slice(1).join('/') : "");
-            const secondaryParts = eventIdAndQuery.split('?');
-
-            const eventId = secondaryParts[0];
-            const query = secondaryParts.length > 1 ? secondaryParts[1] : "";
-
-            const via = query.split("via=").filter(p => !!p);
-
-            return { roomIdOrAlias: entity, eventId: eventId, viaServers: via, userId: undefined };
+            const viaServers = new URLSearchParams(queryParameters).getAll('via');
+            return {
+                roomIdOrAlias: decodeURIComponent(entity),
+                eventId: eventId ? decodeURIComponent(eventId) : undefined,
+                viaServers,
+                userId: undefined,
+            };
+        } else {
+            throw new Error("Unexpected entity");
         }
-
-        throw new Error("Unexpected entity");
     }
 }

--- a/src/helpers/Permalinks.ts
+++ b/src/helpers/Permalinks.ts
@@ -48,7 +48,7 @@ export class Permalinks {
      * @returns {string} A room permalink.
      */
     public static forRoom(roomIdOrAlias: string, viaServers: string[] = []): string {
-        return `https://matrix.to/#/${roomIdOrAlias}${Permalinks.encodeViaArgs(viaServers)}`;
+        return `https://matrix.to/#/${encodeURIComponent(roomIdOrAlias)}${Permalinks.encodeViaArgs(viaServers)}`;
     }
 
     /**
@@ -57,7 +57,7 @@ export class Permalinks {
      * @returns {string} A user permalink.
      */
     public static forUser(userId: string): string {
-        return `https://matrix.to/#/${userId}`;
+        return `https://matrix.to/#/${encodeURIComponent(userId)}`;
     }
 
     /**
@@ -68,7 +68,7 @@ export class Permalinks {
      * @returns {string} An event permalink.
      */
     public static forEvent(roomIdOrAlias: string, eventId: string, viaServers: string[] = []): string {
-        return `https://matrix.to/#/${roomIdOrAlias}/${eventId}${Permalinks.encodeViaArgs(viaServers)}`;
+        return `https://matrix.to/#/${encodeURIComponent(roomIdOrAlias)}/${encodeURIComponent(eventId)}${Permalinks.encodeViaArgs(viaServers)}`;
     }
 
     /**

--- a/src/helpers/Permalinks.ts
+++ b/src/helpers/Permalinks.ts
@@ -5,22 +5,22 @@
  */
 export interface PermalinkParts {
     /**
-     * The room ID or alias the permalink references. May be null.
+     * The room ID or alias the permalink references. May be undefined.
      */
     roomIdOrAlias: string;
 
     /**
-     * The user ID the permalink references. May be null.
+     * The user ID the permalink references. May be undefined.
      */
     userId: string;
 
     /**
-     * The event ID the permalink references. May be null.
+     * The event ID the permalink references. May be undefined.
      */
     eventId: string;
 
     /**
-     * The servers the permalink is routed through. May be null or empty.
+     * The servers the permalink is routed through. May be undefined or empty.
      */
     viaServers: string[];
 }

--- a/src/helpers/Permalinks.ts
+++ b/src/helpers/Permalinks.ts
@@ -48,7 +48,7 @@ export class Permalinks {
      * @returns {string} A room permalink.
      */
     public static forRoom(roomIdOrAlias: string, viaServers: string[] = []): string {
-        return `https://matrix.to/#/${encodeURIComponent(roomIdOrAlias)}${Permalinks.encodeViaArgs(viaServers)}`;
+        return `https://matrix.to/#/${roomIdOrAlias}${Permalinks.encodeViaArgs(viaServers)}`;
     }
 
     /**
@@ -57,7 +57,7 @@ export class Permalinks {
      * @returns {string} A user permalink.
      */
     public static forUser(userId: string): string {
-        return `https://matrix.to/#/${encodeURIComponent(userId)}`;
+        return `https://matrix.to/#/${userId}`;
     }
 
     /**
@@ -68,7 +68,7 @@ export class Permalinks {
      * @returns {string} An event permalink.
      */
     public static forEvent(roomIdOrAlias: string, eventId: string, viaServers: string[] = []): string {
-        return `https://matrix.to/#/${encodeURIComponent(roomIdOrAlias)}/${encodeURIComponent(eventId)}${Permalinks.encodeViaArgs(viaServers)}`;
+        return `https://matrix.to/#/${roomIdOrAlias}/${eventId}${Permalinks.encodeViaArgs(viaServers)}`;
     }
 
     /**

--- a/test/helpers/PermalinksTest.ts
+++ b/test/helpers/PermalinksTest.ts
@@ -153,7 +153,7 @@ describe('Permalinks', () => {
             expect(Permalinks.parseUrl(Permalinks.forEvent(roomId, eventId, via))).toMatchObject(expected);
         });
 
-        it('should parse room ID permalink URLs with via servers', () => {
+        it('should parse room ID URLs with via servers', () => {
             const roomId = "!example:example.org";
             const via = ["example.org"];
             const expected: PermalinkParts = { userId: undefined, roomIdOrAlias: roomId, viaServers: via, eventId: undefined };

--- a/test/helpers/PermalinksTest.ts
+++ b/test/helpers/PermalinksTest.ts
@@ -17,14 +17,14 @@ describe('Permalinks', () => {
         it('should generate a URL for a room ID with via', () => {
             const roomId = "!test:example.org";
             const via = ['one.example.org', 'two.example.org'];
-            const expected = `https://matrix.to/#/${roomId}?via=${via.join("via=")}`;
+            const expected = `https://matrix.to/#/${roomId}?via=${via.join("&via=")}`;
             expect(Permalinks.forRoom(roomId, via)).toBe(expected);
         });
 
         it('should generate a URL for a room alias with via', () => {
             const roomAlias = "#test:example.org";
             const via = ['one.example.org', 'two.example.org'];
-            const expected = `https://matrix.to/#/${roomAlias}?via=${via.join("via=")}`;
+            const expected = `https://matrix.to/#/${roomAlias}?via=${via.join("&via=")}`;
             expect(Permalinks.forRoom(roomAlias, via)).toBe(expected);
         });
     });
@@ -48,7 +48,7 @@ describe('Permalinks', () => {
             const roomId = "!test:example.org";
             const eventId = "$test:example.org";
             const via = ['one.example.org', 'two.example.org'];
-            const expected = `https://matrix.to/#/${roomId}/${eventId}?via=${via.join("via=")}`;
+            const expected = `https://matrix.to/#/${roomId}/${eventId}?via=${via.join("&via=")}`;
             expect(Permalinks.forEvent(roomId, eventId, via)).toBe(expected);
         });
 
@@ -56,7 +56,7 @@ describe('Permalinks', () => {
             const roomAlias = "#test:example.org";
             const eventId = "$test:example.org";
             const via = ['one.example.org', 'two.example.org'];
-            const expected = `https://matrix.to/#/${roomAlias}/${eventId}?via=${via.join("via=")}`;
+            const expected = `https://matrix.to/#/${roomAlias}/${eventId}?via=${via.join("&via=")}`;
             expect(Permalinks.forEvent(roomAlias, eventId, via)).toBe(expected);
         });
     });
@@ -132,8 +132,7 @@ describe('Permalinks', () => {
             const eventId = "$ev:example.org";
             const via = ["one.example.org", "two.example.org"];
             const expected: PermalinkParts = { userId: undefined, roomIdOrAlias: roomId, viaServers: via, eventId };
-            const parsed = Permalinks.parseUrl(`https://matrix.to/#/${roomId}/${eventId}?via=${via.join("via=")}`);
-
+            const parsed = Permalinks.parseUrl(`https://matrix.to/#/${roomId}/${eventId}?via=${via.join("&via=")}`);
             expect(parsed).toMatchObject(<any>expected);
         });
 
@@ -142,8 +141,16 @@ describe('Permalinks', () => {
             const eventId = "$ev:example.org";
             const via = ["one.example.org", "two.example.org"];
             const expected: PermalinkParts = { userId: undefined, roomIdOrAlias: roomId, viaServers: via, eventId };
-            const parsed = Permalinks.parseUrl(`https://matrix.to/#/${roomId}/${eventId}?via=${via.join("via=")}`);
+            const parsed = Permalinks.parseUrl(`https://matrix.to/#/${roomId}/${eventId}?via=${via.join("&via=")}`);
 
+            expect(parsed).toMatchObject(<any>expected);
+        });
+
+        it('should parse room ID permalink URLs with via servers', () => {
+            const roomId = "!example:example.org";
+            const via = ["example.org"];
+            const expected: PermalinkParts = { userId: undefined, roomIdOrAlias: roomId, viaServers: via, eventId: undefined };
+            const parsed = Permalinks.parseUrl(`https://matrix.to/#/${roomId}/?via=${via.join("&via=")}`);
             expect(parsed).toMatchObject(<any>expected);
         });
     });

--- a/test/helpers/PermalinksTest.ts
+++ b/test/helpers/PermalinksTest.ts
@@ -4,27 +4,27 @@ describe('Permalinks', () => {
     describe('forRoom', () => {
         it('should generate a URL for a room ID', () => {
             const roomId = "!test:example.org";
-            const expected = `https://matrix.to/#/${encodeURIComponent(roomId)}`;
+            const expected = `https://matrix.to/#/${roomId}`;
             expect(Permalinks.forRoom(roomId)).toBe(expected);
         });
 
         it('should generate a URL for a room alias', () => {
             const roomAlias = "#test:example.org";
-            const expected = `https://matrix.to/#/${encodeURIComponent(roomAlias)}`;
+            const expected = `https://matrix.to/#/${roomAlias}`;
             expect(Permalinks.forRoom(roomAlias)).toBe(expected);
         });
 
         it('should generate a URL for a room ID with via', () => {
             const roomId = "!test:example.org";
             const via = ['one.example.org', 'two.example.org'];
-            const expected = `https://matrix.to/#/${encodeURIComponent(roomId)}?via=${via.map(encodeURIComponent).join("&via=")}`;
+            const expected = `https://matrix.to/#/${roomId}?via=${via.join("&via=")}`;
             expect(Permalinks.forRoom(roomId, via)).toBe(expected);
         });
 
         it('should generate a URL for a room alias with via', () => {
             const roomAlias = "#test:example.org";
             const via = ['one.example.org', 'two.example.org'];
-            const expected = `https://matrix.to/#/${encodeURIComponent(roomAlias)}?via=${via.map(encodeURIComponent).join("&via=")}`;
+            const expected = `https://matrix.to/#/${roomAlias}?via=${via.join("&via=")}`;
             expect(Permalinks.forRoom(roomAlias, via)).toBe(expected);
         });
     });
@@ -33,14 +33,14 @@ describe('Permalinks', () => {
         it('should generate a URL for an event ID with room ID', () => {
             const roomId = "!test:example.org";
             const eventId = "$test:example.org";
-            const expected = `https://matrix.to/#/${encodeURIComponent(roomId)}/${encodeURIComponent(eventId)}`;
+            const expected = `https://matrix.to/#/${roomId}/${eventId}`;
             expect(Permalinks.forEvent(roomId, eventId)).toBe(expected);
         });
 
         it('should generate a URL for an event ID with room alias', () => {
             const roomAlias = "#test:example.org";
             const eventId = "$test:example.org";
-            const expected = `https://matrix.to/#/${encodeURIComponent(roomAlias)}/${encodeURIComponent(eventId)}`;
+            const expected = `https://matrix.to/#/${roomAlias}/${eventId}`;
             expect(Permalinks.forEvent(roomAlias, eventId)).toBe(expected);
         });
 
@@ -48,7 +48,7 @@ describe('Permalinks', () => {
             const roomId = "!test:example.org";
             const eventId = "$test:example.org";
             const via = ['one.example.org', 'two.example.org'];
-            const expected = `https://matrix.to/#/${encodeURIComponent(roomId)}/${encodeURIComponent(eventId)}?via=${via.map(encodeURIComponent).join("&via=")}`;
+            const expected = `https://matrix.to/#/${roomId}/${eventId}?via=${via.join("&via=")}`;
             expect(Permalinks.forEvent(roomId, eventId, via)).toBe(expected);
         });
 
@@ -56,7 +56,7 @@ describe('Permalinks', () => {
             const roomAlias = "#test:example.org";
             const eventId = "$test:example.org";
             const via = ['one.example.org', 'two.example.org'];
-            const expected = `https://matrix.to/#/${encodeURIComponent(roomAlias)}/${encodeURIComponent(eventId)}?via=${via.map(encodeURIComponent).join("&via=")}`;
+            const expected = `https://matrix.to/#/${roomAlias}/${eventId}?via=${via.join("&via=")}`;
             expect(Permalinks.forEvent(roomAlias, eventId, via)).toBe(expected);
         });
     });
@@ -64,7 +64,7 @@ describe('Permalinks', () => {
     describe('forUser', () => {
         it('should generate a URL for a user ID', () => {
             const userId = "@test:example.org";
-            const expected = `https://matrix.to/#/${encodeURIComponent(userId)}`;
+            const expected = `https://matrix.to/#/${userId}`;
             expect(Permalinks.forUser(userId)).toBe(expected);
         });
     });

--- a/test/helpers/PermalinksTest.ts
+++ b/test/helpers/PermalinksTest.ts
@@ -4,27 +4,27 @@ describe('Permalinks', () => {
     describe('forRoom', () => {
         it('should generate a URL for a room ID', () => {
             const roomId = "!test:example.org";
-            const expected = `https://matrix.to/#/${roomId}`;
+            const expected = `https://matrix.to/#/${encodeURIComponent(roomId)}`;
             expect(Permalinks.forRoom(roomId)).toBe(expected);
         });
 
         it('should generate a URL for a room alias', () => {
             const roomAlias = "#test:example.org";
-            const expected = `https://matrix.to/#/${roomAlias}`;
+            const expected = `https://matrix.to/#/${encodeURIComponent(roomAlias)}`;
             expect(Permalinks.forRoom(roomAlias)).toBe(expected);
         });
 
         it('should generate a URL for a room ID with via', () => {
             const roomId = "!test:example.org";
             const via = ['one.example.org', 'two.example.org'];
-            const expected = `https://matrix.to/#/${roomId}?via=${via.join("&via=")}`;
+            const expected = `https://matrix.to/#/${encodeURIComponent(roomId)}?via=${via.map(encodeURIComponent).join("&via=")}`;
             expect(Permalinks.forRoom(roomId, via)).toBe(expected);
         });
 
         it('should generate a URL for a room alias with via', () => {
             const roomAlias = "#test:example.org";
             const via = ['one.example.org', 'two.example.org'];
-            const expected = `https://matrix.to/#/${roomAlias}?via=${via.join("&via=")}`;
+            const expected = `https://matrix.to/#/${encodeURIComponent(roomAlias)}?via=${via.map(encodeURIComponent).join("&via=")}`;
             expect(Permalinks.forRoom(roomAlias, via)).toBe(expected);
         });
     });
@@ -33,14 +33,14 @@ describe('Permalinks', () => {
         it('should generate a URL for an event ID with room ID', () => {
             const roomId = "!test:example.org";
             const eventId = "$test:example.org";
-            const expected = `https://matrix.to/#/${roomId}/${eventId}`;
+            const expected = `https://matrix.to/#/${encodeURIComponent(roomId)}/${encodeURIComponent(eventId)}`;
             expect(Permalinks.forEvent(roomId, eventId)).toBe(expected);
         });
 
         it('should generate a URL for an event ID with room alias', () => {
             const roomAlias = "#test:example.org";
             const eventId = "$test:example.org";
-            const expected = `https://matrix.to/#/${roomAlias}/${eventId}`;
+            const expected = `https://matrix.to/#/${encodeURIComponent(roomAlias)}/${encodeURIComponent(eventId)}`;
             expect(Permalinks.forEvent(roomAlias, eventId)).toBe(expected);
         });
 
@@ -48,7 +48,7 @@ describe('Permalinks', () => {
             const roomId = "!test:example.org";
             const eventId = "$test:example.org";
             const via = ['one.example.org', 'two.example.org'];
-            const expected = `https://matrix.to/#/${roomId}/${eventId}?via=${via.join("&via=")}`;
+            const expected = `https://matrix.to/#/${encodeURIComponent(roomId)}/${encodeURIComponent(eventId)}?via=${via.map(encodeURIComponent).join("&via=")}`;
             expect(Permalinks.forEvent(roomId, eventId, via)).toBe(expected);
         });
 
@@ -56,7 +56,7 @@ describe('Permalinks', () => {
             const roomAlias = "#test:example.org";
             const eventId = "$test:example.org";
             const via = ['one.example.org', 'two.example.org'];
-            const expected = `https://matrix.to/#/${roomAlias}/${eventId}?via=${via.join("&via=")}`;
+            const expected = `https://matrix.to/#/${encodeURIComponent(roomAlias)}/${encodeURIComponent(eventId)}?via=${via.map(encodeURIComponent).join("&via=")}`;
             expect(Permalinks.forEvent(roomAlias, eventId, via)).toBe(expected);
         });
     });
@@ -64,7 +64,7 @@ describe('Permalinks', () => {
     describe('forUser', () => {
         it('should generate a URL for a user ID', () => {
             const userId = "@test:example.org";
-            const expected = `https://matrix.to/#/${userId}`;
+            const expected = `https://matrix.to/#/${encodeURIComponent(userId)}`;
             expect(Permalinks.forUser(userId)).toBe(expected);
         });
     });
@@ -81,6 +81,7 @@ describe('Permalinks', () => {
             const parsed = Permalinks.parseUrl(`https://matrix.to/#/${userId}`);
 
             expect(parsed).toMatchObject(<any>expected);
+            expect(Permalinks.parseUrl(Permalinks.forUser(userId))).toMatchObject(expected);
         });
 
         it('should parse room alias URLs', () => {
@@ -94,6 +95,7 @@ describe('Permalinks', () => {
             const parsed = Permalinks.parseUrl(`https://matrix.to/#/${roomId}`);
 
             expect(parsed).toMatchObject(<any>expected);
+            expect(Permalinks.parseUrl(Permalinks.forRoom(roomId))).toMatchObject(expected);
         });
 
         it('should parse room ID URLs', () => {
@@ -107,6 +109,7 @@ describe('Permalinks', () => {
             const parsed = Permalinks.parseUrl(`https://matrix.to/#/${roomId}`);
 
             expect(parsed).toMatchObject(<any>expected);
+            expect(Permalinks.parseUrl(Permalinks.forRoom(roomId))).toMatchObject(expected);
         });
 
         it('should parse room alias permalink URLs', () => {
@@ -116,6 +119,7 @@ describe('Permalinks', () => {
             const parsed = Permalinks.parseUrl(`https://matrix.to/#/${roomId}/${eventId}`);
 
             expect(parsed).toMatchObject(<any>expected);
+            expect(Permalinks.parseUrl(Permalinks.forEvent(roomId, eventId))).toMatchObject(expected);
         });
 
         it('should parse room ID permalink URLs', () => {
@@ -125,6 +129,7 @@ describe('Permalinks', () => {
             const parsed = Permalinks.parseUrl(`https://matrix.to/#/${roomId}/${eventId}`);
 
             expect(parsed).toMatchObject(<any>expected);
+            expect(Permalinks.parseUrl(Permalinks.forEvent(roomId, eventId))).toMatchObject(expected);
         });
 
         it('should parse room alias permalink URLs with via servers', () => {
@@ -134,6 +139,7 @@ describe('Permalinks', () => {
             const expected: PermalinkParts = { userId: undefined, roomIdOrAlias: roomId, viaServers: via, eventId };
             const parsed = Permalinks.parseUrl(`https://matrix.to/#/${roomId}/${eventId}?via=${via.join("&via=")}`);
             expect(parsed).toMatchObject(<any>expected);
+            expect(Permalinks.parseUrl(Permalinks.forEvent(roomId, eventId, via))).toMatchObject(expected);
         });
 
         it('should parse room ID permalink URLs with via servers', () => {
@@ -144,6 +150,7 @@ describe('Permalinks', () => {
             const parsed = Permalinks.parseUrl(`https://matrix.to/#/${roomId}/${eventId}?via=${via.join("&via=")}`);
 
             expect(parsed).toMatchObject(<any>expected);
+            expect(Permalinks.parseUrl(Permalinks.forEvent(roomId, eventId, via))).toMatchObject(expected);
         });
 
         it('should parse room ID permalink URLs with via servers', () => {
@@ -152,6 +159,7 @@ describe('Permalinks', () => {
             const expected: PermalinkParts = { userId: undefined, roomIdOrAlias: roomId, viaServers: via, eventId: undefined };
             const parsed = Permalinks.parseUrl(`https://matrix.to/#/${roomId}/?via=${via.join("&via=")}`);
             expect(parsed).toMatchObject(<any>expected);
+            expect(Permalinks.parseUrl(Permalinks.forRoom(roomId, via))).toMatchObject(expected);
         });
     });
 });


### PR DESCRIPTION
Previously it was skipping `&via` and just joining `via` when there were more servers. And it also just would not attempt to parse via servers when there was no event id to go with a room.

Closes https://github.com/turt2live/matrix-bot-sdk/issues/299

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

* [x] Tests written for all new code
* [x] Linter has been satisfied
* [x] Sign-off given on the changes (see CONTRIBUTING.md)
