### PR TITLE
Allow setting of the User-Agent header

### DIFF
--- a/src/MatrixClient.ts
+++ b/src/MatrixClient.ts
@@ -70,6 +70,11 @@ export class MatrixClient extends EventEmitter {
     public syncingTimeout = 30000;
 
     /**
+     * A custom User-Agent string applied to HTTP requests.
+     */
+    public userAgent?: string;
+
+    /**
      * The crypto manager instance for this client. Generally speaking, this shouldn't
      * need to be accessed but is made available.
      *
@@ -2002,6 +2007,9 @@ export class MatrixClient extends EventEmitter {
         const headers = {};
         if (this.accessToken) {
             headers["Authorization"] = `Bearer ${this.accessToken}`;
+        }
+        if (this.userAgent) {
+            headers["User-Agent"] = this.userAgent;
         }
         return doHttpRequest(this.homeserverUrl, method, endpoint, qs, body, headers, timeout, raw, contentType, noEncoding);
     }

--- a/test/MatrixClientTest.ts
+++ b/test/MatrixClientTest.ts
@@ -156,6 +156,21 @@ describe('MatrixClient', () => {
             await Promise.all([client.doRequest("GET", "/test"), http.flushAllExpected()]);
         });
 
+        it('should send the custom User-Agent header', async () => {
+            const { client, http } = createTestClient();
+
+            const userAgent = "example/0.0.0 (example)";
+            client.userAgent = userAgent;
+
+            // noinspection TypeScriptValidateJSTypes
+            http.when("GET", "/test").respond(200, (path, content, req) => {
+                expect(req.headers["User-Agent"]).toEqual(userAgent);
+                return {};
+            });
+
+            await Promise.all([client.doRequest("GET", "/test"), http.flushAllExpected()]);
+        });
+
         it('should send application/json by default', async () => {
             const { client, http } = createTestClient();
 


### PR DESCRIPTION
I’d like to be able to set a User-Agent string for the purposes of better identifying the bot in server logs and generally just to be a good netizen.

Here’s a simple implementation but anything that allows setting headers would do, if you’d prefer to have a more generic extension point instead.

## Checklist

* [x] Tests written for all new code
* [x] Linter has been satisfied
* [x] Sign-off given on the changes (see CONTRIBUTING.md)
