### PR TITLE
Catch when CryptoClient can't find room members

### DIFF
--- a/src/e2ee/CryptoClient.ts
+++ b/src/e2ee/CryptoClient.ts
@@ -108,7 +108,7 @@ export class CryptoClient {
      * @param roomId The room ID.
      * @param event The event.
      */
-    public async onRoomEvent(roomId: string, event: any) {
+    public async onRoomEvent(roomId: string, event: any): Promise<void> {
         await this.roomTracker.onRoomEvent(roomId, event);
         if (typeof event['state_key'] !== 'string') return;
         if (event['type'] === 'm.room.member') {
@@ -116,8 +116,10 @@ export class CryptoClient {
             if (membership.effectiveMembership !== 'join' && membership.effectiveMembership !== 'invite') return;
             await this.engine.addTrackedUsers([membership.membershipFor]);
         } else if (event['type'] === 'm.room.encryption') {
-            const members = await this.client.getRoomMembers(roomId, null, ['join', 'invite']);
-            await this.engine.addTrackedUsers(members.map(e => e.membershipFor));
+            return this.client.getRoomMembers(roomId, null, ['join', 'invite']).then(
+                members => this.engine.addTrackedUsers(members.map(e => e.membershipFor)),
+                e => void LogService.error("CryptoClient", `Error getting members of room ${roomId}:`, e),
+            );
         }
     }
 


### PR DESCRIPTION
CryptoClient#onRoomEvent may throw when looking up the members of a room with a client that isn't in the room, which can happen if appservice namespaces are broad & the appservice receives events for rooms that some of its managed clients are not members of.

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

* [ ] Tests written for all new code
  * Not adding a test for this until there are tests for appservice crypto.
* [x] Linter has been satisfied
