### PR TITLE
Add getEventNearestToTimestamp

### DIFF
--- a/src/MatrixClient.ts
+++ b/src/MatrixClient.ts
@@ -997,6 +997,18 @@ export class MatrixClient extends EventEmitter {
     }
 
     /**
+     * Get the nearest event to a given timestamp, either forwards or backwards.
+     * @param roomId The room ID to get the context in.
+     * @param ts The event ID to get the context of.
+     * @param dir The maximum number of events to return on either side of the event.
+     * @returns The ID and origin server timestamp of the event.
+     */
+    @timedMatrixClientFunctionCall()
+    public async getEventNearestToTimestamp(roomId: string, ts: number, dir: "f"|"b"): Promise<{event_id: string, origin_server_ts: number}> {
+        return await this.doRequest("GET", "/_matrix/client/v3/rooms/" + encodeURIComponent(roomId) + "/timestamp_to_event", { ts, dir });
+    }
+
+    /**
      * Gets the profile for a given user
      * @param {string} userId the user ID to lookup
      * @returns {Promise<any>} the profile of the user

--- a/src/SynapseAdminApis.ts
+++ b/src/SynapseAdminApis.ts
@@ -479,4 +479,16 @@ export class SynapseAdminApis {
     public async makeRoomAdmin(roomId: string, userId?: string): Promise<void> {
         return this.client.doRequest("POST", `/_synapse/admin/v1/rooms/${encodeURIComponent(roomId)}/make_room_admin`, {}, { user_id: userId });
     }
+
+    /**
+    * Get the nearest event to a given timestamp, either forwards or backwards. You do not
+    * need to be joined to the room to retrieve this information.
+    * @param roomId The room ID to get the context in.
+    * @param ts The event ID to get the context of.
+    * @param dir The maximum number of events to return on either side of the event.
+    * @returns The ID and origin server timestamp of the event.
+    */
+    public async getEventNearestToTimestamp(roomId: string, ts: number, dir: "f"|"b"): Promise<{event_id: string, origin_server_ts: number}> {
+        return await this.client.doRequest("GET", "/_synapse/admin/v1/rooms/" + encodeURIComponent(roomId) + "/timestamp_to_event", { ts, dir });
+    }
 }

--- a/test/MatrixClientTest.ts
+++ b/test/MatrixClientTest.ts
@@ -2759,6 +2759,34 @@ describe('MatrixClient', () => {
         });
     });
 
+    describe('getEventNearestToTimestamp', () => {
+        it('should use the right endpoint', async () => {
+            const { client, http, hsUrl } = createTestClient();
+            const roomId = "!abc123:example.org";
+            const dir = "f";
+            const timestamp = 1234;
+
+            const eventId = "$def456:example.org";
+            const originServerTs = 4567;
+
+            http.when("GET", "/_matrix/client/v3/rooms").respond(200, (path, _content, req) => {
+                expect(path).toEqual(`${hsUrl}/_matrix/client/v3/rooms/${encodeURIComponent(roomId)}/timestamp_to_event`);
+                expect(req.queryParams['dir']).toEqual(dir);
+                expect(req.queryParams['ts']).toEqual(timestamp.toString());
+
+                return {
+                    event_id: eventId,
+                    origin_server_ts: originServerTs,
+                };
+            });
+
+            const [result] = await Promise.all([client.getEventNearestToTimestamp(roomId, timestamp, dir), http.flushAllExpected()]);
+            expect(result).toBeDefined();
+            expect(result.event_id).toEqual(eventId);
+            expect(result.origin_server_ts).toMatchObject(originServerTs);
+        });
+    });
+
     describe('getUserProfile', () => {
         it('should call the right endpoint', async () => {
             const { client, http, hsUrl } = createTestClient();

--- a/test/SynapseAdminApisTest.ts
+++ b/test/SynapseAdminApisTest.ts
@@ -531,5 +531,33 @@ describe('SynapseAdminApis', () => {
                 await Promise.all([client.makeRoomAdmin(roomId, userId), http.flushAllExpected()]);
             });
         });
+
+        describe('getEventNearestToTimestamp', () => {
+            it('should use the right endpoint', async () => {
+                const { client, http, hsUrl } = createTestSynapseAdminClient();
+                const roomId = "!abc123:example.org";
+                const dir = "f";
+                const timestamp = 1234;
+
+                const eventId = "$def456:example.org";
+                const originServerTs = 4567;
+
+                http.when("GET", "/_synapse/admin/v1/rooms").respond(200, (path, _content, req) => {
+                    expect(path).toEqual(`${hsUrl}/_synapse/admin/v1/rooms/${encodeURIComponent(roomId)}/timestamp_to_event`);
+                    expect(req.queryParams['dir']).toEqual(dir);
+                    expect(req.queryParams['ts']).toEqual(timestamp.toString());
+
+                    return {
+                        event_id: eventId,
+                        origin_server_ts: originServerTs,
+                    };
+                });
+
+                const [result] = await Promise.all([client.getEventNearestToTimestamp(roomId, timestamp, dir), http.flushAllExpected()]);
+                expect(result).toBeDefined();
+                expect(result.event_id).toEqual(eventId);
+                expect(result.origin_server_ts).toMatchObject(originServerTs);
+            });
+        });
     });
 });


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

Implements https://spec.matrix.org/latest/client-server-api/#get_matrixclientv1roomsroomidtimestamp_to_event / https://matrix-org.github.io/synapse/latest/admin_api/rooms.html#room-timestamp-to-event-api

## Checklist

* [ ] Tests written for all new code
* [ ] Linter has been satisfied
* [ ] Sign-off given on the changes (see CONTRIBUTING.md)
