### PR TITLE
Update express to 4.17.21

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   ],
   "dependencies": {
     "@matrix-org/matrix-sdk-crypto-nodejs": "0.1.0-beta.6",
-    "@types/express": "^4.17.20",
+    "@types/express": "^4.17.21",
     "another-json": "^0.2.0",
     "async-lock": "^1.4.0",
     "chalk": "4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -804,10 +804,10 @@
     "@types/range-parser" "*"
     "@types/send" "*"
 
-"@types/express@^4.17.20":
-  version "4.17.20"
-  resolved "https://registry.yarnpkg.com/@types/express/-/express-4.17.20.tgz#e7c9b40276d29e38a4e3564d7a3d65911e2aa433"
-  integrity sha512-rOaqlkgEvOW495xErXMsmyX3WKBInbhG5eqojXYi3cGUaLoRDlXa5d52fkfWZT963AZ3v2eZ4MbKE6WpDAGVsw==
+"@types/express@^4.17.21":
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/@types/express/-/express-4.17.21.tgz#c26d4a151e60efe0084b23dc3369ebc631ed192d"
+  integrity sha512-ejlPM315qwLpaQlQDTjPdsUFSc6ZsP4AN6AlWnogPjQ7CVi7PYF3YVz+CY3jE2pwYf7E/7HlDAN0rV2GxTG0HQ==
   dependencies:
     "@types/body-parser" "*"
     "@types/express-serve-static-core" "^4.17.33"


### PR DESCRIPTION
Prevents type incompatibilities with newer `@types/node` versions a.k.a:

```
$ npm run build

> matrix-bifrost@0.4.2 build
> tsc

node_modules/@types/express-serve-static-core/index.d.ts:589:18 - error TS2430: Interface 'Response<ResBody, Locals, StatusCode>' incorrectly extends interface 'ServerResponse<IncomingMessage>'.
  Property 'req' is optional in type 'Response<ResBody, Locals, StatusCode>' but required in type 'ServerResponse<IncomingMessage>'.

589 export interface Response<
                     ~~~~~~~~

node_modules/@types/express/index.d.ts:58:55 - error TS2344: Type 'Response<any, Record<string, any>>' does not satisfy the constraint 'ServerResponse<IncomingMessage>'.
  Property 'req' is optional in type 'Response<any, Record<string, any>>' but required in type 'ServerResponse<IncomingMessage>'.

58     var static: serveStatic.RequestHandlerConstructor<Response>;
                                                         ~~~~~~~~
```