### PR TITLE
Add retryable request function to thrown error

### DIFF
--- a/src/MatrixClient.ts
+++ b/src/MatrixClient.ts
@@ -2015,7 +2015,11 @@ export class MatrixClient extends EventEmitter {
         if (this.accessToken) {
             headers["Authorization"] = `Bearer ${this.accessToken}`;
         }
-        return doHttpRequest(this.homeserverUrl, method, endpoint, qs, body, headers, timeout, raw, contentType, noEncoding);
+        const requestFn = () => doHttpRequest(this.homeserverUrl, method, endpoint, qs, body, headers, timeout, raw, contentType, noEncoding);
+        return requestFn().catch((e) => {
+            e.retryRequest = requestFn;
+            throw e;
+        });
     }
 }
 


### PR DESCRIPTION
This allows sdk consumers to retry requests as-is when they catch a thrown error, most notably this will include the same transaction id for PUT requests. (Needed to fix issues like https://github.com/matrix-org/matrix-appservice-bridge/issues/513)

## Checklist

* [ ] Tests written for all new code
* [x] Linter has been satisfied
* [x] Sign-off given on the changes (see CONTRIBUTING.md)
