### PR TITLE
upgrade `htmlencode` to 0.0.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "glob-to-regexp": "^0.4.1",
     "hash.js": "^1.1.7",
     "html-to-text": "^9.0.5",
-    "htmlencode": "^0.0.4",
+    "htmlencode": "^0.0.5",
     "lowdb": "1",
     "lru-cache": "^10.0.1",
     "mkdirp": "^3.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3535,10 +3535,10 @@ html-to-text@^9.0.5:
     htmlparser2 "^8.0.2"
     selderee "^0.11.0"
 
-htmlencode@^0.0.4:
-  version "0.0.4"
-  resolved "https://registry.yarnpkg.com/htmlencode/-/htmlencode-0.0.4.tgz#f7e2d6afbe18a87a78e63ba3308e753766740e3f"
-  integrity sha512-0uDvNVpzj/E2TfvLLyyXhKBRvF1y84aZsyRxRXFsQobnHaL4pcaXk+Y9cnFlvnxrBLeXDNq/VJBD+ngdBgQG1w==
+htmlencode@^0.0.5:
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/htmlencode/-/htmlencode-0.0.5.tgz#c0e082b398027141d08eae13f6625a0963925afc"
+  integrity sha512-wdWZ6HysCVu5BurawxrETKdN4u7DbDjfbAXlpDRHohchq598Ire4ZCKVxvbH327mggKL5hwW0RykPKN0GxgpdA==
 
 htmlparser2@^8.0.0, htmlparser2@^8.0.2:
   version "8.0.2"


### PR DESCRIPTION
<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->
`htmlencode` is a very old library that used the deprecated `util._extend` node api.

a few days ago i submitted a pr to that project to fix it (danmactough/node-htmlencode#9). this fix was released in version 0.0.5

upgrading the library here should solve the node warning that currently gets logged every single time you use `matrix-bot-sdk`

```
[meow@laptop matrix-bot]$ node .
(node:44288) [DEP0060] DeprecationWarning: The `util._extend` API is deprecated. Please use Object.assign() instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
```

## Checklist

* [x] Tests written for all new code
* [x] Linter has been satisfied
* [x] Sign-off given on the changes (see CONTRIBUTING.md)
