### PR TITLE
Add support for cross signing the bot's device

### DIFF
--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -23,7 +23,7 @@ jobs:
   build:
     strategy:
       matrix:
-        node: [ 22, 24 ]
+        node: [ 24 ]
     name: 'Build Node ${{ matrix.node }}'
     runs-on: ubuntu-latest
     steps:
@@ -38,7 +38,7 @@ jobs:
   build-docs:
     strategy:
       matrix:
-        node: [ 22, 24 ]
+        node: [ 24 ]
     name: 'Build Docs Node ${{ matrix.node }}'
     runs-on: ubuntu-latest
     steps:
@@ -52,7 +52,7 @@ jobs:
   tests:
     strategy:
       matrix:
-        node: [ 22, 24 ]
+        node: [ 24 ]
     name: 'Tests Node ${{ matrix.node }}'
     runs-on: ubuntu-latest
     steps:

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "tsconfig.json"
   ],
   "dependencies": {
-    "@matrix-org/matrix-sdk-crypto-nodejs": "^0.4.0",
+    "@matrix-org/matrix-sdk-crypto-nodejs": "^0.5.1",
     "@types/express": "^4.17.20",
     "another-json": "^0.2.0",
     "async-lock": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "main": "./lib/index.js",
   "typings": "./lib/index.d.ts",
   "engines": {
-    "node": ">=22.0.0"
+    "node": ">=24.0.0"
   },
   "keywords": [
     "matrix",

--- a/src/e2ee/CryptoClient.ts
+++ b/src/e2ee/CryptoClient.ts
@@ -360,7 +360,8 @@ export class CryptoClient {
             const masterKeyEvent = await client.getAccountData<{encrypted: Record<string, any>}>("m.cross_signing.master");
             const userSigningKeyEvent = await client.getAccountData<{encrypted: Record<string, any>}>("m.cross_signing.user_signing");
             const selfSigningKeyEvent = await client.getAccountData<{encrypted: Record<string, any>}>("m.cross_signing.self_signing");
-            return Boolean(masterKeyEvent?.encrypted?.[keyId] &&
+            return Boolean(keyInfo.algorithm &&
+                masterKeyEvent?.encrypted?.[keyId] &&
                 userSigningKeyEvent?.encrypted?.[keyId] &&
                 selfSigningKeyEvent?.encrypted?.[keyId]);
         } catch {

--- a/src/e2ee/CryptoClient.ts
+++ b/src/e2ee/CryptoClient.ts
@@ -306,7 +306,10 @@ export class CryptoClient {
     public async confirmIdentityWithRecoveryKey(key: string): Promise<void> {
         const machine = this.engine.machine;
         const ownDevice = await machine.getDevice(machine.userId, machine.deviceId);
-        if (ownDevice.isCrossSigningTrusted()) {
+        if (!ownDevice) {
+            LogService.debug("CryptoClient", "Own device not set up yet");
+            throw new Error("Own device not set up yet");
+        } else if (ownDevice.isCrossSigningTrusted()) {
             LogService.debug("CryptoClient", "Cryptographic identity already confirmed");
             return;
         }
@@ -376,16 +379,14 @@ export class CryptoClient {
      */
     public async createIdentity(key?: string): Promise<string> {
         const client = this.client;
-        let secretStorageKey: SecretStorageKey;
-        if (key === undefined) {
-            secretStorageKey = SecretStorageKey.createRandomKey();
-        } else {
-            secretStorageKey = await this.getDefaultSecretStorageKey(key);
-        }
+        const secretStorageKey =
+            key === undefined
+                ? SecretStorageKey.createRandomKey()
+                : await this.getDefaultSecretStorageKey(key);
         const machine = this.engine.machine;
         const bootstrapRequests = await machine.bootstrapCrossSigning(true);
         if (bootstrapRequests.uploadKeysReq) {
-            this.engine.processOutgoingRequests([bootstrapRequests.uploadKeysReq]);
+            await this.engine.processOutgoingRequests([bootstrapRequests.uploadKeysReq]);
         }
         await client.doRequest("POST", "/_matrix/client/v3/keys/device_signing/upload", null, JSON.parse(bootstrapRequests.uploadSigningKeysReq));
         await this.engine.processOutgoingRequests([bootstrapRequests.uploadSignaturesReq]);

--- a/src/e2ee/CryptoClient.ts
+++ b/src/e2ee/CryptoClient.ts
@@ -300,7 +300,7 @@ export class CryptoClient {
     /**
      * Confirm's the bot's identity by using a recovery key or passphrase.
      *
-     * @param {string} key The recovery key or passphrase.
+     * @param key The recovery key or passphrase.
      */
     @requiresReady()
     public async confirmIdentityWithRecoveryKey(key: string): Promise<void> {
@@ -325,7 +325,7 @@ export class CryptoClient {
         const userSigningKeyEvent = await client.getAccountData("m.cross_signing.user_signing");
         const selfSigningKeyEvent = await client.getAccountData("m.cross_signing.self_signing");
 
-        const signatureUploadRequest = await this.engine.machine.importSecretsFromSecretStorage(
+        const signatureUploadRequest = await machine.importSecretsFromSecretStorage(
             secretStorageKey,
             new SecretStorageItems({
                 masterKey: JSON.stringify(masterKeyEvent),
@@ -345,7 +345,7 @@ export class CryptoClient {
      * has the cross-signing keys stored in Secret Storage.  It does not check
      * the validity of the stored keys.
      *
-     * @returns {boolean} Whether recovery has been set up on this account.
+     * @returns Whether recovery has been set up on this account.
      */
     public async isRecoveryAvailable(): Promise<boolean> {
         try {
@@ -375,7 +375,7 @@ export class CryptoClient {
      * Note: only works if the bot does not have an existing cryptographic
      * identity, since this doesn't yet perform user interactive auth.
      *
-     * @returns {string} The recovery key.
+     * @returns The recovery key.
      */
     public async createIdentity(): Promise<string> {
         const client = this.client;
@@ -385,7 +385,7 @@ export class CryptoClient {
         if (bootstrapRequests.uploadKeysReq) {
             this.engine.processOutgoingRequests([bootstrapRequests.uploadKeysReq]);
         }
-        await this.client.doRequest("POST", "/_matrix/client/v3/keys/device_signing/upload", null, JSON.parse(bootstrapRequests.uploadSigningKeysReq));
+        await client.doRequest("POST", "/_matrix/client/v3/keys/device_signing/upload", null, JSON.parse(bootstrapRequests.uploadSigningKeysReq));
         await this.engine.processOutgoingRequests([bootstrapRequests.uploadSignaturesReq]);
 
         await client.setAccountData("m.secret_storage.default_key", {key: secretStorageKey.keyId});

--- a/src/e2ee/CryptoClient.ts
+++ b/src/e2ee/CryptoClient.ts
@@ -111,6 +111,7 @@ export class CryptoClient {
         LogService.debug("CryptoClient", "Running with device Ed25519 identity:", this.deviceEd25519); // info so all bots know for debugging
 
         this.ready = true;
+        this.client.emit("crypto.ready");
     }
 
     /**

--- a/src/e2ee/CryptoClient.ts
+++ b/src/e2ee/CryptoClient.ts
@@ -394,13 +394,13 @@ export class CryptoClient {
             // If we created a new secret storage key (`key` was not given),
             // then we need to save the key info to account data, and set it as
             // the default key.
-            await client.setAccountData("m.secret_storage.default_key", {key: secretStorageKey.keyId});
+            await client.setAccountData("m.secret_storage.default_key", {key: secretStorageKey.keyId()});
             await client.setAccountData(secretStorageKey.eventType(), JSON.parse(secretStorageKey.accountDataContent()));
         }
         const secretStorageItems = await machine.exportSecretsForSecretStorage(secretStorageKey);
-        await client.setAccountData("m.cross_signing.master", secretStorageItems.masterKey);
-        await client.setAccountData("m.cross_signing.user_signing", secretStorageItems.userSigningKey);
-        await client.setAccountData("m.cross_signing.self_signing", secretStorageItems.selfSigningKey);
+        await client.setAccountData("m.cross_signing.master", JSON.parse(secretStorageItems.masterKey));
+        await client.setAccountData("m.cross_signing.user_signing", JSON.parse(secretStorageItems.userSigningKey));
+        await client.setAccountData("m.cross_signing.self_signing", JSON.parse(secretStorageItems.selfSigningKey));
 
         return secretStorageKey.toBase58();
     }

--- a/src/e2ee/CryptoClient.ts
+++ b/src/e2ee/CryptoClient.ts
@@ -7,7 +7,7 @@ import {
     Attachment,
     EncryptedAttachment,
     SecretStorageKey,
-    SecretStorageEvents,
+    SecretStorageItems,
 } from "@matrix-org/matrix-sdk-crypto-nodejs";
 
 import { MatrixClient } from "../MatrixClient";
@@ -327,10 +327,10 @@ export class CryptoClient {
 
         const signatureUploadRequest = await this.engine.machine.importSecretsFromSecretStorage(
             secretStorageKey,
-            new SecretStorageEvents({
-                masterKeyEvent: JSON.stringify(masterKeyEvent),
-                userSigningKeyEvent: JSON.stringify(userSigningKeyEvent),
-                selfSigningKeyEvent: JSON.stringify(selfSigningKeyEvent),
+            new SecretStorageItems({
+                masterKey: JSON.stringify(masterKeyEvent),
+                userSigningKey: JSON.stringify(userSigningKeyEvent),
+                selfSigningKey: JSON.stringify(selfSigningKeyEvent),
             }),
         );
         LogService.debug("CryptoClient", "Secrets obtained");
@@ -389,11 +389,11 @@ export class CryptoClient {
         await this.engine.processOutgoingRequests([bootstrapRequests.uploadSignaturesReq]);
 
         await client.setAccountData("m.secret_storage.default_key", {key: secretStorageKey.keyId});
-        await client.setAccountData(secretStorageKey.eventType(), JSON.parse(secretStorageKey.eventContent()));
-        const secretStorageEvents = await machine.exportSecretsForSecretStorage(secretStorageKey);
-        await client.setAccountData("m.cross_signing.master", secretStorageEvents.masterKeyEvent);
-        await client.setAccountData("m.cross_signing.user_signing", secretStorageEvents.userSigningKeyEvent);
-        await client.setAccountData("m.cross_signing.self_signing", secretStorageEvents.selfSigningKeyEvent);
+        await client.setAccountData(secretStorageKey.eventType(), JSON.parse(secretStorageKey.accountDataContent()));
+        const secretStorageItems = await machine.exportSecretsForSecretStorage(secretStorageKey);
+        await client.setAccountData("m.cross_signing.master", secretStorageItems.masterKey);
+        await client.setAccountData("m.cross_signing.user_signing", secretStorageItems.userSigningKey);
+        await client.setAccountData("m.cross_signing.self_signing", secretStorageItems.selfSigningKey);
 
         return secretStorageKey.toBase58();
     }

--- a/src/e2ee/CryptoClient.ts
+++ b/src/e2ee/CryptoClient.ts
@@ -313,13 +313,7 @@ export class CryptoClient {
 
         LogService.debug("CryptoClient", "Confirming cryptographic identity with recovery key");
         const client = this.client;
-        const defaultKeyData = await client.getAccountData<{key: string}>("m.secret_storage.default_key");
-        if (!defaultKeyData || !defaultKeyData.key) {
-            throw new Error("No default recovery key available");
-        }
-        const keyAccountDataName = "m.secret_storage.key." + defaultKeyData.key;
-        const keyInfo = await client.getAccountData(keyAccountDataName);
-        const secretStorageKey = SecretStorageKey.fromAccountData(key, keyAccountDataName, JSON.stringify(keyInfo));
+        const secretStorageKey = await this.getDefaultSecretStorageKey(key);
 
         const masterKeyEvent = await client.getAccountData("m.cross_signing.master");
         const userSigningKeyEvent = await client.getAccountData("m.cross_signing.user_signing");
@@ -356,7 +350,7 @@ export class CryptoClient {
             }
             const keyId = defaultKeyData.key;
             const keyAccountDataName = "m.secret_storage.key." + keyId;
-            const keyInfo = await client.getAccountData(keyAccountDataName);
+            const keyInfo = await client.getAccountData<{algorithm: string}>(keyAccountDataName);
             const masterKeyEvent = await client.getAccountData<{encrypted: Record<string, any>}>("m.cross_signing.master");
             const userSigningKeyEvent = await client.getAccountData<{encrypted: Record<string, any>}>("m.cross_signing.user_signing");
             const selfSigningKeyEvent = await client.getAccountData<{encrypted: Record<string, any>}>("m.cross_signing.self_signing");
@@ -370,17 +364,24 @@ export class CryptoClient {
     }
 
     /**
-     * Creates the bot's cryptographic identity and resets/creates recovery with a
-     * new random recovery key.
+     * Creates the bot's cryptographic identity.
      *
      * Note: only works if the bot does not have an existing cryptographic
      * identity, since this doesn't yet perform user interactive auth.
      *
+     * @param key The recovery key or passphrase.  If omitted, a new recovery
+     * key will be created and set as the default recovery key.
+     *
      * @returns The recovery key.
      */
-    public async createIdentity(): Promise<string> {
+    public async createIdentity(key?: string): Promise<string> {
         const client = this.client;
-        const secretStorageKey = SecretStorageKey.createRandomKey();
+        let secretStorageKey: SecretStorageKey;
+        if (key === undefined) {
+            secretStorageKey = SecretStorageKey.createRandomKey();
+        } else {
+            secretStorageKey = await this.getDefaultSecretStorageKey(key);
+        }
         const machine = this.engine.machine;
         const bootstrapRequests = await machine.bootstrapCrossSigning(true);
         if (bootstrapRequests.uploadKeysReq) {
@@ -389,13 +390,37 @@ export class CryptoClient {
         await client.doRequest("POST", "/_matrix/client/v3/keys/device_signing/upload", null, JSON.parse(bootstrapRequests.uploadSigningKeysReq));
         await this.engine.processOutgoingRequests([bootstrapRequests.uploadSignaturesReq]);
 
-        await client.setAccountData("m.secret_storage.default_key", {key: secretStorageKey.keyId});
-        await client.setAccountData(secretStorageKey.eventType(), JSON.parse(secretStorageKey.accountDataContent()));
+        if (key === undefined) {
+            // If we created a new secret storage key (`key` was not given),
+            // then we need to save the key info to account data, and set it as
+            // the default key.
+            await client.setAccountData("m.secret_storage.default_key", {key: secretStorageKey.keyId});
+            await client.setAccountData(secretStorageKey.eventType(), JSON.parse(secretStorageKey.accountDataContent()));
+        }
         const secretStorageItems = await machine.exportSecretsForSecretStorage(secretStorageKey);
         await client.setAccountData("m.cross_signing.master", secretStorageItems.masterKey);
         await client.setAccountData("m.cross_signing.user_signing", secretStorageItems.userSigningKey);
         await client.setAccountData("m.cross_signing.self_signing", secretStorageItems.selfSigningKey);
 
         return secretStorageKey.toBase58();
+    }
+
+    /**
+     * Create a `SecretStorageKey` from the given key, assuming it is the default
+     * secret storage key.
+     *
+     * @param key The recovery key or passphrase.
+     *
+     * @returns The `SecretStorageKey`.
+     */
+    private async getDefaultSecretStorageKey(key: string): Promise<SecretStorageKey> {
+        const client = this.client;
+        const defaultKeyData = await client.getAccountData<{key: string}>("m.secret_storage.default_key");
+        if (!defaultKeyData || !defaultKeyData.key) {
+            throw new Error("No default recovery key available");
+        }
+        const keyAccountDataName = "m.secret_storage.key." + defaultKeyData.key;
+        const keyInfo = await client.getAccountData(keyAccountDataName);
+        return SecretStorageKey.fromAccountData(key, keyAccountDataName, JSON.stringify(keyInfo));
     }
 }

--- a/src/e2ee/CryptoClient.ts
+++ b/src/e2ee/CryptoClient.ts
@@ -6,6 +6,8 @@ import {
     RoomId,
     Attachment,
     EncryptedAttachment,
+    SecretStorageKey,
+    SecretStorageEvents,
 } from "@matrix-org/matrix-sdk-crypto-nodejs";
 
 import { MatrixClient } from "../MatrixClient";
@@ -292,5 +294,106 @@ export class CryptoClient {
         );
         const decrypted = Attachment.decrypt(encrypted);
         return Buffer.from(decrypted);
+    }
+
+    /**
+     * Confirm's the bot's identity by using a recovery key or passphrase.
+     *
+     * @param {string} key The recovery key or passphrase.
+     */
+    @requiresReady()
+    public async confirmIdentityWithRecoveryKey(key: string): Promise<void> {
+        const machine = this.engine.machine;
+        const ownDevice = await machine.getDevice(machine.userId, machine.deviceId);
+        if (ownDevice.isCrossSigningTrusted()) {
+            LogService.debug("CryptoClient", "Cryptographic identity already confirmed");
+            return;
+        }
+
+        LogService.debug("CryptoClient", "Confirming cryptographic identity with recovery key");
+        const client = this.client;
+        const defaultKeyData = await client.getAccountData<{key: string}>("m.secret_storage.default_key");
+        if (!defaultKeyData || !defaultKeyData.key) {
+            throw new Error("No default recovery key available");
+        }
+        const keyAccountDataName = "m.secret_storage.key." + defaultKeyData.key;
+        const keyInfo = await client.getAccountData(keyAccountDataName);
+        const secretStorageKey = SecretStorageKey.fromAccountData(key, keyAccountDataName, JSON.stringify(keyInfo));
+
+        const masterKeyEvent = await client.getAccountData("m.cross_signing.master");
+        const userSigningKeyEvent = await client.getAccountData("m.cross_signing.user_signing");
+        const selfSigningKeyEvent = await client.getAccountData("m.cross_signing.self_signing");
+
+        const signatureUploadRequest = await this.engine.machine.importSecretsFromSecretStorage(
+            secretStorageKey,
+            new SecretStorageEvents({
+                masterKeyEvent: JSON.stringify(masterKeyEvent),
+                userSigningKeyEvent: JSON.stringify(userSigningKeyEvent),
+                selfSigningKeyEvent: JSON.stringify(selfSigningKeyEvent),
+            }),
+        );
+        LogService.debug("CryptoClient", "Secrets obtained");
+        await this.engine.processOutgoingRequests([signatureUploadRequest]);
+        LogService.debug("CryptoClient", "Identity confirmed");
+    }
+
+    /**
+     * Has recovery been set up on this account.
+     *
+     * Checks whether the account has a default Secret Storage key set up, and
+     * has the cross-signing keys stored in Secret Storage.  It does not check
+     * the validity of the stored keys.
+     *
+     * @returns {boolean} Whether recovery has been set up on this account.
+     */
+    public async isRecoveryAvailable(): Promise<boolean> {
+        try {
+            const client = this.client;
+            const defaultKeyData = await client.getAccountData<{key: string}>("m.secret_storage.default_key");
+            if (!defaultKeyData.key) {
+                return false;
+            }
+            const keyId = defaultKeyData.key;
+            const keyAccountDataName = "m.secret_storage.key." + keyId;
+            const keyInfo = await client.getAccountData(keyAccountDataName);
+            const masterKeyEvent = await client.getAccountData<{encrypted: Record<string, any>}>("m.cross_signing.master");
+            const userSigningKeyEvent = await client.getAccountData<{encrypted: Record<string, any>}>("m.cross_signing.user_signing");
+            const selfSigningKeyEvent = await client.getAccountData<{encrypted: Record<string, any>}>("m.cross_signing.self_signing");
+            return Boolean(masterKeyEvent?.encrypted?.[keyId] &&
+                userSigningKeyEvent?.encrypted?.[keyId] &&
+                selfSigningKeyEvent?.encrypted?.[keyId]);
+        } catch {
+            return false;
+        }
+    }
+
+    /**
+     * Creates the bot's cryptographic identity and resets/creates recovery with a
+     * new random recovery key.
+     *
+     * Note: only works if the bot does not have an existing cryptographic
+     * identity, since this doesn't yet perform user interactive auth.
+     *
+     * @returns {string} The recovery key.
+     */
+    public async createIdentity(): Promise<string> {
+        const client = this.client;
+        const secretStorageKey = SecretStorageKey.createRandomKey();
+        const machine = this.engine.machine;
+        const bootstrapRequests = await machine.bootstrapCrossSigning(true);
+        if (bootstrapRequests.uploadKeysReq) {
+            this.engine.processOutgoingRequests([bootstrapRequests.uploadKeysReq]);
+        }
+        await this.client.doRequest("POST", "/_matrix/client/v3/keys/device_signing/upload", null, JSON.parse(bootstrapRequests.uploadSigningKeysReq));
+        await this.engine.processOutgoingRequests([bootstrapRequests.uploadSignaturesReq]);
+
+        await client.setAccountData("m.secret_storage.default_key", {key: secretStorageKey.keyId});
+        await client.setAccountData(secretStorageKey.eventType(), JSON.parse(secretStorageKey.eventContent()));
+        const secretStorageEvents = await machine.exportSecretsForSecretStorage(secretStorageKey);
+        await client.setAccountData("m.cross_signing.master", secretStorageEvents.masterKeyEvent);
+        await client.setAccountData("m.cross_signing.user_signing", secretStorageEvents.userSigningKeyEvent);
+        await client.setAccountData("m.cross_signing.self_signing", secretStorageEvents.selfSigningKeyEvent);
+
+        return secretStorageKey.toBase58();
     }
 }

--- a/src/e2ee/RustEngine.ts
+++ b/src/e2ee/RustEngine.ts
@@ -10,6 +10,7 @@ import {
     KeysUploadRequest,
     KeysQueryRequest,
     ToDeviceRequest,
+    SignatureUploadRequest,
 } from "@matrix-org/matrix-sdk-crypto-nodejs";
 import * as AsyncLock from "async-lock";
 
@@ -63,7 +64,8 @@ export class RustEngine {
                 case RequestType.RoomMessage:
                     throw new Error("Bindings error: Sending room messages is not supported");
                 case RequestType.SignatureUpload:
-                    throw new Error("Bindings error: Backup feature not possible");
+                    await this.processSignatureUploadRequest(request as SignatureUploadRequest);
+                    break;
                 case RequestType.KeysBackup:
                     throw new Error("Bindings error: Backup feature not possible");
                 default:
@@ -159,5 +161,11 @@ export class RustEngine {
     private async actuallyProcessToDeviceRequest(id: string, type: string, messages: Record<string, Record<string, unknown>>) {
         const resp = await this.client.sendToDevices(type, messages);
         await this.machine.markRequestAsSent(id, RequestType.ToDevice, JSON.stringify(resp));
+    }
+
+    private async processSignatureUploadRequest(request: SignatureUploadRequest) {
+        const req = JSON.parse(request.body);
+        const resp = await this.client.doRequest("POST", "/_matrix/client/v3/keys/signatures/upload", null, req.signed_keys);
+        await this.machine.markRequestAsSent(request.id, request.type, JSON.stringify(resp));
     }
 }

--- a/src/e2ee/RustEngine.ts
+++ b/src/e2ee/RustEngine.ts
@@ -43,7 +43,7 @@ export class RustEngine {
         const filteredRequests = types.length ?
             requests.filter((request) => types.includes(request.type)) :
             requests;
-        await this.processOutgoingRequests(requests);
+        await this.processOutgoingRequests(filteredRequests);
     }
 
     public async processOutgoingRequests(requests: Awaited<ReturnType<typeof OlmMachine.prototype.outgoingRequests>>) {

--- a/src/e2ee/RustEngine.ts
+++ b/src/e2ee/RustEngine.ts
@@ -39,8 +39,14 @@ export class RustEngine {
     private async runOnly(...types: RequestType[]) {
         // Note: we should not be running this until it runs out, so cache the value into a variable
         const requests = await this.machine.outgoingRequests();
+        const filteredRequests = types.length ?
+            requests.filter((request) => types.includes(request.type)) :
+            requests;
+        await this.processOutgoingRequests(requests);
+    }
+
+    public async processOutgoingRequests(requests: Awaited<ReturnType<typeof OlmMachine.prototype.outgoingRequests>>) {
         for (const request of requests) {
-            if (types.length && !types.includes(request.type)) continue;
             switch (request.type) {
                 case RequestType.KeysUpload:
                     await this.processKeysUploadRequest(request);

--- a/test/encryption/CryptoClientTest.ts
+++ b/test/encryption/CryptoClientTest.ts
@@ -641,7 +641,7 @@ describe('CryptoClient', () => {
                 http1.flushAllExpected(),
             ]);
 
-            // Recovery is not available yet
+            // Recovery is not available yet.
             http1.when("GET", "/user/%40alice%3Aexample.org/account_data/").respond(404, (path, obj) => {
                 return {
                     errcode: "M_NOT_FOUND",
@@ -653,7 +653,7 @@ describe('CryptoClient', () => {
                 http1.flushAllExpected(),
             ]))[0]).toBe(false);
 
-            // Create the cryptographic identity, and secret storage
+            // Create the cryptographic identity, and secret storage.
             let crossSigningKeys: Record<string, any>;
             const accountData: Record<string, any> = {};
             http1.when("POST", "/keys/device_signing/upload").respond(200, (path, obj) => {
@@ -663,6 +663,9 @@ describe('CryptoClient', () => {
             http1.when("POST", "/keys/signatures/upload").respond(200, (path, obj) => {
                 return {};
             });
+            // `createIdentity` will set 5 items of account data: the default
+            // secret storage key, the secret storage key info, and the three
+            // cross-signing private keys.
             for (let i = 0; i < 5; i++) {
                 http1.when("PUT", "/user/%40alice%3Aexample.org/account_data/").respond(200, (path, obj) => {
                     const components = path.split("/");
@@ -676,7 +679,9 @@ describe('CryptoClient', () => {
                 http1.flushAllExpected(),
             ]);
 
-            // Recovery should be available now
+            // Recovery should be available now.
+            // `isRecoveryAvailable` will read the 5 items of account data that
+            // were set by `createIdentity`.
             for (let i = 0; i < 5; i++) {
                 http1.when("GET", "/user/%40alice%3Aexample.org/account_data/").respond(200, (path, obj) => {
                     const components = path.split("/");
@@ -689,7 +694,7 @@ describe('CryptoClient', () => {
                 http1.flushAllExpected(),
             ]))[0]).toBe(true);
 
-            // The user then starts another client and cross-signs using the recovery key
+            // The user then starts another client and cross-signs using the recovery key.
             const { client: client2, http: http2 } = createTestClient(null, userId, cryptoStoreType);
 
             // Initialize the crypto client.
@@ -704,7 +709,7 @@ describe('CryptoClient', () => {
                 };
             });
             http2.when("POST", "/keys/query").respond(200, (path, obj) => {
-                // We need to send the cross-signing keys in addition to the device keys
+                // We need to send the cross-signing keys in addition to the device keys.
                 return {
                     device_keys: {
                         [userId]: deviceKeys,
@@ -725,7 +730,9 @@ describe('CryptoClient', () => {
                 http2.flushAllExpected(),
             ]);
 
-            // The client cross-signs using the recovery key
+            // The client cross-signs using the recovery key.
+            // `confirmIdentityWithRecoveryKey` will read the 5 items of account
+            // data that were set by `createIdentity`.
             for (let i = 0; i < 5; i++) {
                 http2.when("GET", "/user/%40alice%3Aexample.org/account_data/").respond(200, (path, obj) => {
                     const components = path.split("/");

--- a/test/encryption/CryptoClientTest.ts
+++ b/test/encryption/CryptoClientTest.ts
@@ -609,4 +609,137 @@ describe('CryptoClient', () => {
             await Promise.all([prom1, prom2]);
         });
     });
+
+    describe('cross-signing', () => {
+        it('should save and load cross-signing keys', async () => testCryptoStores(async (cryptoStoreType) => {
+            const userId = "@alice:example.org";
+
+            // The user has one client that will set up cross-signing.
+            const { client: client1, http: http1 } = createTestClient(null, userId, cryptoStoreType);
+
+            // Initialize the crypto client.
+            client1.getWhoAmI = () => Promise.resolve({ user_id: userId, device_id: TEST_DEVICE_ID+"1" });
+            const deviceKeys: Record<string, any> = {};
+            http1.when("POST", "/keys/upload").respond(200, (path, obj) => {
+                deviceKeys[(obj.device_keys as any).device_id] = obj.device_keys;
+                return {
+                    one_time_key_counts: {
+                        // Enough to trick the OlmMachine into thinking it has enough keys
+                        [OTKAlgorithm.Signed]: 1000,
+                    },
+                };
+            });
+            http1.when("POST", "/keys/query").respond(200, (path, obj) => {
+                return {
+                    device_keys: {
+                        [userId]: deviceKeys,
+                    }
+                };
+            });
+            await Promise.all([
+                client1.crypto.prepare([]),
+                http1.flushAllExpected(),
+            ]);
+
+            // Recovery is not available yet
+            http1.when("GET", "/user/%40alice%3Aexample.org/account_data/").respond(404, (path, obj) => {
+                return {
+                    errcode: "M_NOT_FOUND",
+                    error: "Not found"
+                };
+            });
+            expect((await Promise.all([
+                client1.crypto.isRecoveryAvailable(),
+                http1.flushAllExpected(),
+            ]))[0]).toBe(false);
+
+            // Create the cryptographic identity, and secret storage
+            let crossSigningKeys: Record<string, any>;
+            const accountData: Record<string, any> = {};
+            http1.when("POST", "/keys/device_signing/upload").respond(200, (path, obj) => {
+                crossSigningKeys = obj;
+                return {};
+            });
+            http1.when("POST", "/keys/signatures/upload").respond(200, (path, obj) => {
+                return {};
+            });
+            for (let i = 0; i < 5; i++) {
+                http1.when("PUT", "/user/%40alice%3Aexample.org/account_data/").respond(200, (path, obj) => {
+                    const components = path.split("/");
+                    const name = components.at(-1);
+                    accountData[name] = obj;
+                    return {};
+                });
+            }
+            const [recoveryKey, ] = await Promise.all([
+                client1.crypto.createIdentity(),
+                http1.flushAllExpected(),
+            ]);
+
+            // Recovery should be available now
+            for (let i = 0; i < 5; i++) {
+                http1.when("GET", "/user/%40alice%3Aexample.org/account_data/").respond(200, (path, obj) => {
+                    const components = path.split("/");
+                    const name = components.at(-1);
+                    return accountData[name];
+                });
+            }
+            expect((await Promise.all([
+                client1.crypto.isRecoveryAvailable(),
+                http1.flushAllExpected(),
+            ]))[0]).toBe(true);
+
+            // The user then starts another client and cross-signs using the recovery key
+            const { client: client2, http: http2 } = createTestClient(null, userId, cryptoStoreType);
+
+            // Initialize the crypto client.
+            client2.getWhoAmI = () => Promise.resolve({ user_id: userId, device_id: TEST_DEVICE_ID+"2" });
+            http2.when("POST", "/keys/upload").respond(200, (path, obj) => {
+                deviceKeys[(obj.device_keys as any).device_id] = obj.device_keys;
+                return {
+                    one_time_key_counts: {
+                        // Enough to trick the OlmMachine into thinking it has enough keys
+                        [OTKAlgorithm.Signed]: 1000,
+                    },
+                };
+            });
+            http2.when("POST", "/keys/query").respond(200, (path, obj) => {
+                // We need to send the cross-signing keys in addition to the device keys
+                return {
+                    device_keys: {
+                        [userId]: deviceKeys,
+                    },
+                    master_keys: {
+                        [userId]: crossSigningKeys.master_key,
+                    },
+                    user_signing_keys: {
+                        [userId]: crossSigningKeys.user_signing_key,
+                    },
+                    self_signing_keys: {
+                        [userId]: crossSigningKeys.self_signing_key,
+                    },
+                };
+            });
+            await Promise.all([
+                client2.crypto.prepare([]),
+                http2.flushAllExpected(),
+            ]);
+
+            // The client cross-signs using the recovery key
+            for (let i = 0; i < 5; i++) {
+                http2.when("GET", "/user/%40alice%3Aexample.org/account_data/").respond(200, (path, obj) => {
+                    const components = path.split("/");
+                    const name = components.at(-1);
+                    return accountData[name];
+                });
+            }
+            http2.when("POST", "/keys/signatures/upload").respond(200, (path, obj) => {
+                return {};
+            });
+            await Promise.all([
+                client2.crypto.confirmIdentityWithRecoveryKey(recoveryKey),
+                http2.flushAllExpected(),
+            ]);
+        }));
+    });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -762,10 +762,10 @@
   dependencies:
     lodash "^4.17.21"
 
-"@matrix-org/matrix-sdk-crypto-nodejs@^0.4.0":
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/@matrix-org/matrix-sdk-crypto-nodejs/-/matrix-sdk-crypto-nodejs-0.4.0.tgz#39bab710de8ae31cb7790a0ab0ee26855848a503"
-  integrity sha512-+qqgpn39XFSbsD0dFjssGO9vHEP7sTyfs8yTpt8vuqWpUpF20QMwpCZi0jpYw7GxjErNTsMshopuo8677DfGEA==
+"@matrix-org/matrix-sdk-crypto-nodejs@^0.5.1":
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/@matrix-org/matrix-sdk-crypto-nodejs/-/matrix-sdk-crypto-nodejs-0.5.1.tgz#0de7c0a397155b9b8badc0d3ca24653ed6a8ec8d"
+  integrity sha512-m1nTFhUJv8AZCvuVmZ0wgYsFaseVNMhl3Jqu18KoHs7TQa+mmAW4q3xY6MuVApd75Zu9E0ooQeA5obUZdQ24OA==
   dependencies:
     https-proxy-agent "^7.0.5"
     node-downloader-helper "^2.1.9"


### PR DESCRIPTION
Adds functions to cross-sign the bot's device using a recovery key.

Depends on https://github.com/matrix-org/matrix-rust-sdk-crypto-nodejs/pull/67, so merging will need to wait for that, plus a release of matrix-rust-sdk-crypto-nodejs, plus bumping `package.json`.

Cross-signing can be done by doing something like:

```
if (config.recoveryKey) {
    client.on("crypto.ready", async () => {
        await client.crypto.confirmIdentityWithRecoveryKey(config.recoveryKey);
    });
}
```

## Checklist

* [ ] Tests written for all new code
* [x] Linter has been satisfied
* [x] Sign-off given on the changes (see CONTRIBUTING.md)

Signed-off-by: Hubert Chathi <hubertc@element.io>
