### PR TITLE
Tests: move bindNullEngine to helper module

### DIFF
--- a/test/encryption/CryptoClientTest.ts
+++ b/test/encryption/CryptoClientTest.ts
@@ -3,24 +3,7 @@ import HttpBackend from 'matrix-mock-request';
 
 import { EncryptedFile, MatrixClient, MembershipEvent, OTKAlgorithm, RoomEncryptionAlgorithm } from "../../src";
 import { createTestClient, testCryptoStores, TEST_DEVICE_ID } from "../TestUtils";
-
-export function bindNullEngine(http: HttpBackend) {
-    http.when("POST", "/keys/upload").respond(200, (path, obj) => {
-        expect(obj).toMatchObject({
-
-        });
-        return {
-            one_time_key_counts: {
-                // Enough to trick the OlmMachine into thinking it has enough keys
-                [OTKAlgorithm.Signed]: 1000,
-            },
-        };
-    });
-    // Some oddity with the rust-sdk bindings during setup
-    http.when("POST", "/keys/query").respond(200, (path, obj) => {
-        return {};
-    });
-}
+import { bindNullEngine } from "./CryptoTestUtils";
 
 describe('CryptoClient', () => {
     it('should not have a device ID or be ready until prepared', () => testCryptoStores(async (cryptoStoreType) => {

--- a/test/encryption/CryptoTestUtils.ts
+++ b/test/encryption/CryptoTestUtils.ts
@@ -1,0 +1,21 @@
+import HttpBackend from "matrix-mock-request";
+
+import { OTKAlgorithm } from "../../src";
+
+export function bindNullEngine(http: HttpBackend) {
+    http.when("POST", "/keys/upload").respond(200, (path, obj) => {
+        expect(obj).toMatchObject({
+
+        });
+        return {
+            one_time_key_counts: {
+                // Enough to trick the OlmMachine into thinking it has enough keys
+                [OTKAlgorithm.Signed]: 1000,
+            },
+        };
+    });
+    // Some oddity with the rust-sdk bindings during setup
+    http.when("POST", "/keys/query").respond(200, (path, obj) => {
+        return {};
+    });
+}

--- a/test/encryption/RoomTrackerTest.ts
+++ b/test/encryption/RoomTrackerTest.ts
@@ -2,7 +2,7 @@ import * as simple from "simple-mock";
 
 import { EncryptionEventContent, MatrixClient, RoomEncryptionAlgorithm, RoomTracker } from "../../src";
 import { createTestClient, testCryptoStores, TEST_DEVICE_ID } from "../TestUtils";
-import { bindNullEngine } from "./CryptoClientTest";
+import { bindNullEngine } from "./CryptoTestUtils";
 
 function prepareQueueSpies(
     client: MatrixClient,


### PR DESCRIPTION
When it is imported from CryptoClientTest, it causes Jest to parse the tests in that file multiple times.  Moving it to a standalone, non-test module avoids that.

## Checklist

* [x] Tests written for all new code (existing tests pass)
* [x] Linter has been satisfied
* [x] Sign-off given on the changes (see CONTRIBUTING.md)

Signed-off-by: Andrew Ferrazzutti <andrewf@element.io>