### PR TITLE
Tests: increase default flushAllExpected timeout

### DIFF
--- a/test/TestUtils.ts
+++ b/test/TestUtils.ts
@@ -38,6 +38,8 @@ export function createTestClient(
     accessToken: string;
 } {
     const http = new HttpBackend();
+    const flushAllExpectedOrig = http.flushAllExpected.bind(http);
+    http.flushAllExpected = (opts) => flushAllExpectedOrig({ ...opts, timeout: opts?.timeout ?? 2000 });
     const hsUrl = "https://localhost";
     const accessToken = "s3cret";
     const client = new MatrixClient(hsUrl, accessToken, storage, cryptoStoreType !== undefined ? new RustSdkCryptoStorageProvider(tmp.dirSync().name, cryptoStoreType) : null);


### PR DESCRIPTION
The default timeout of 1 second is often too short for tests to pass consistently, so increase it to 2 seconds.

## Checklist

* [x] Tests written for all new code (existing tests pass)
* [x] Linter has been satisfied
* [x] Sign-off given on the changes (see CONTRIBUTING.md)

Signed-off-by: Andrew Ferrazzutti <andrewf@element.io>
