### PR TITLE
Don't include fallbacks in rich replies

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
     "glob-to-regexp": "^0.4.1",
     "hash.js": "^1.1.7",
     "html-to-text": "^9.0.5",
-    "htmlencode": "^0.0.4",
     "lowdb": "1",
     "lru-cache": "^10.0.1",
     "mkdirp": "^3.0.1",

--- a/src/MatrixClient.ts
+++ b/src/MatrixClient.ts
@@ -1,5 +1,4 @@
 import { EventEmitter } from "events";
-import { htmlEncode } from "htmlencode";
 import { htmlToText } from "html-to-text";
 
 import { IStorageProvider } from "./storage/IStorageProvider";
@@ -1226,13 +1225,11 @@ export class MatrixClient extends EventEmitter {
      * @param {string} roomId the room ID to reply in
      * @param {any} event the event to reply to
      * @param {string} text the text to reply with
-     * @param {string} html the HTML to reply with, or falsey to use the `text`
+     * @param {string} html the HTML to reply with. Optional.
      * @returns {Promise<string>} resolves to the event ID which was sent
      */
     @timedMatrixClientFunctionCall()
     public replyText(roomId: string, event: any, text: string, html: string = null): Promise<string> {
-        if (!html) html = htmlEncode(text);
-
         const reply = RichReply.createFor(roomId, event, text, html);
         return this.sendMessage(roomId, reply);
     }
@@ -1258,13 +1255,11 @@ export class MatrixClient extends EventEmitter {
      * @param {string} roomId the room ID to reply in
      * @param {any} event the event to reply to
      * @param {string} text the text to reply with
-     * @param {string} html the HTML to reply with, or falsey to use the `text`
+     * @param {string} html the HTML to reply with. Optional.
      * @returns {Promise<string>} resolves to the event ID which was sent
      */
     @timedMatrixClientFunctionCall()
     public replyNotice(roomId: string, event: any, text: string, html: string = null): Promise<string> {
-        if (!html) html = htmlEncode(text);
-
         const reply = RichReply.createFor(roomId, event, text, html);
         reply['msgtype'] = 'm.notice';
         return this.sendMessage(roomId, reply);

--- a/src/helpers/RichReply.ts
+++ b/src/helpers/RichReply.ts
@@ -14,23 +14,10 @@ export class RichReply {
      * @param {string} roomId the room ID the event being replied to resides in
      * @param {any} event the event to reply to
      * @param {string} withText the plain text to reply with
-     * @param {string} withHtml the HTML to reply with
+     * @param {string} withHtml the HTML to reply with. Optional.
      * @returns {any} the content of the event representing the reply
      */
-    public static createFor(roomId: string, event: any, withText: string, withHtml: string): any {
-        const originalBody = (event["content"] ? event["content"]["body"] : "") || "";
-        let originalHtml = (event["content"] ? event["content"]["formatted_body"] : "") || null;
-        if (originalHtml === null) {
-            originalHtml = sanitizeHtml(originalBody);
-        }
-
-        const fallbackText = "> <" + event["sender"] + "> " + originalBody.split("\n").join("\n> ");
-        const fallbackHtml = "<mx-reply><blockquote>"
-            + `<a href="https://matrix.to/#/${roomId}/${event["event_id"]}">In reply to</a> `
-            + `<a href="https://matrix.to/#/${event["sender"]}">${event["sender"]}</a>`
-            + "<br />" + originalHtml
-            + "</blockquote></mx-reply>";
-
+    public static createFor(roomId: string, event: any, withText: string, withHtml: string = null): any {
         return {
             "m.relates_to": {
                 "m.in_reply_to": {
@@ -38,9 +25,11 @@ export class RichReply {
                 },
             },
             "msgtype": "m.text", // for those who just want to send the reply as-is
-            "body": fallbackText + "\n\n" + withText,
-            "format": "org.matrix.custom.html",
-            "formatted_body": fallbackHtml + withHtml,
+            "body": withText,
+            ...(withHtml && {
+                "format": "org.matrix.custom.html",
+                "formatted_body": withHtml,
+            }),
         };
     }
 }

--- a/test/MatrixClientTest.ts
+++ b/test/MatrixClientTest.ts
@@ -3512,9 +3512,8 @@ describe('MatrixClient', () => {
                 },
                 "msgtype": "m.text",
                 "format": "org.matrix.custom.html",
-                "body": `> <${originalEvent.sender}> ${originalEvent.content.body}\n\n${replyText}`,
-                // eslint-disable-next-line max-len
-                "formatted_body": `<mx-reply><blockquote><a href="https://matrix.to/#/${roomId}/${originalEvent.event_id}">In reply to</a> <a href="https://matrix.to/#/${originalEvent.sender}">${originalEvent.sender}</a><br />${originalEvent.content.formatted_body}</blockquote></mx-reply>${replyHtml}`,
+                "body": replyText,
+                "formatted_body": replyHtml,
             };
 
             // noinspection TypeScriptValidateJSTypes
@@ -3553,9 +3552,8 @@ describe('MatrixClient', () => {
                 },
                 "msgtype": "m.text",
                 "format": "org.matrix.custom.html",
-                "body": `> <${originalEvent.sender}> ${originalEvent.content.body}\n\n${replyText}`,
-                // eslint-disable-next-line max-len
-                "formatted_body": `<mx-reply><blockquote><a href="https://matrix.to/#/${roomId}/${originalEvent.event_id}">In reply to</a> <a href="https://matrix.to/#/${originalEvent.sender}">${originalEvent.sender}</a><br />${originalEvent.content.formatted_body}</blockquote></mx-reply>${replyHtml}`,
+                "body": replyText,
+                "formatted_body": replyHtml,
             };
 
             const expectedContent = {
@@ -3606,9 +3604,8 @@ describe('MatrixClient', () => {
                 },
                 "msgtype": "m.text",
                 "format": "org.matrix.custom.html",
-                "body": `> <${originalEvent.sender}> ${originalEvent.content.body}\n\n${replyText}`,
-                // eslint-disable-next-line max-len
-                "formatted_body": `<mx-reply><blockquote><a href="https://matrix.to/#/${roomId}/${originalEvent.event_id}">In reply to</a> <a href="https://matrix.to/#/${originalEvent.sender}">${originalEvent.sender}</a><br />${originalEvent.content.formatted_body}</blockquote></mx-reply>${replyHtml}`,
+                "body": replyText,
+                "formatted_body": replyHtml,
             };
 
             client.crypto.isRoomEncrypted = async () => false; // for this test
@@ -3625,7 +3622,7 @@ describe('MatrixClient', () => {
             expect(result).toEqual(eventId);
         }));
 
-        it('should use encoded plain text as the HTML component', async () => {
+        it('should omit HTML when replying with plain text', async () => {
             const { client, http, hsUrl } = createTestClient();
 
             const roomId = "!testing:example.org";
@@ -3639,7 +3636,6 @@ describe('MatrixClient', () => {
                 event_id: "$abc:example.org",
             };
             const replyText = "<testing1234>";
-            const replyHtml = "&lt;testing1234&gt;";
 
             const expectedContent = {
                 "m.relates_to": {
@@ -3648,10 +3644,7 @@ describe('MatrixClient', () => {
                     },
                 },
                 "msgtype": "m.text",
-                "format": "org.matrix.custom.html",
-                "body": `> <${originalEvent.sender}> ${originalEvent.content.body}\n\n${replyText}`,
-                // eslint-disable-next-line max-len
-                "formatted_body": `<mx-reply><blockquote><a href="https://matrix.to/#/${roomId}/${originalEvent.event_id}">In reply to</a> <a href="https://matrix.to/#/${originalEvent.sender}">${originalEvent.sender}</a><br />${originalEvent.content.formatted_body}</blockquote></mx-reply>${replyHtml}`,
+                "body": replyText,
             };
 
             // noinspection TypeScriptValidateJSTypes
@@ -3692,9 +3685,8 @@ describe('MatrixClient', () => {
                 },
                 "msgtype": "m.text",
                 "format": "org.matrix.custom.html",
-                "body": `> <${originalEvent.sender}> ${originalEvent.content.body}\n\n${replyText}`,
-                // eslint-disable-next-line max-len
-                "formatted_body": `<mx-reply><blockquote><a href="https://matrix.to/#/${roomId}/${originalEvent.event_id}">In reply to</a> <a href="https://matrix.to/#/${originalEvent.sender}">${originalEvent.sender}</a><br />${originalEvent.content.formatted_body}</blockquote></mx-reply>${replyHtml}`,
+                "body": replyText,
+                "formatted_body": replyHtml,
             };
 
             // noinspection TypeScriptValidateJSTypes
@@ -3733,9 +3725,8 @@ describe('MatrixClient', () => {
                 },
                 "msgtype": "m.text",
                 "format": "org.matrix.custom.html",
-                "body": `> <${originalEvent.sender}> ${originalEvent.content.body}\n\n${replyText}`,
-                // eslint-disable-next-line max-len
-                "formatted_body": `<mx-reply><blockquote><a href="https://matrix.to/#/${roomId}/${originalEvent.event_id}">In reply to</a> <a href="https://matrix.to/#/${originalEvent.sender}">${originalEvent.sender}</a><br />${originalEvent.content.formatted_body}</blockquote></mx-reply>${replyHtml}`,
+                "body": replyText,
+                "formatted_body": replyHtml,
             };
 
             const expectedContent = {
@@ -3786,9 +3777,8 @@ describe('MatrixClient', () => {
                 },
                 "msgtype": "m.text",
                 "format": "org.matrix.custom.html",
-                "body": `> <${originalEvent.sender}> ${originalEvent.content.body}\n\n${replyText}`,
-                // eslint-disable-next-line max-len
-                "formatted_body": `<mx-reply><blockquote><a href="https://matrix.to/#/${roomId}/${originalEvent.event_id}">In reply to</a> <a href="https://matrix.to/#/${originalEvent.sender}">${originalEvent.sender}</a><br />${originalEvent.content.formatted_body}</blockquote></mx-reply>${replyHtml}`,
+                "body": replyText,
+                "formatted_body": replyHtml,
             };
 
             client.crypto.isRoomEncrypted = async () => false; // for this test
@@ -3831,9 +3821,8 @@ describe('MatrixClient', () => {
                 },
                 "msgtype": "m.notice",
                 "format": "org.matrix.custom.html",
-                "body": `> <${originalEvent.sender}> ${originalEvent.content.body}\n\n${replyText}`,
-                // eslint-disable-next-line max-len
-                "formatted_body": `<mx-reply><blockquote><a href="https://matrix.to/#/${roomId}/${originalEvent.event_id}">In reply to</a> <a href="https://matrix.to/#/${originalEvent.sender}">${originalEvent.sender}</a><br />${originalEvent.content.formatted_body}</blockquote></mx-reply>${replyHtml}`,
+                "body": replyText,
+                "formatted_body": replyHtml,
             };
 
             // noinspection TypeScriptValidateJSTypes
@@ -3872,9 +3861,8 @@ describe('MatrixClient', () => {
                 },
                 "msgtype": "m.notice",
                 "format": "org.matrix.custom.html",
-                "body": `> <${originalEvent.sender}> ${originalEvent.content.body}\n\n${replyText}`,
-                // eslint-disable-next-line max-len
-                "formatted_body": `<mx-reply><blockquote><a href="https://matrix.to/#/${roomId}/${originalEvent.event_id}">In reply to</a> <a href="https://matrix.to/#/${originalEvent.sender}">${originalEvent.sender}</a><br />${originalEvent.content.formatted_body}</blockquote></mx-reply>${replyHtml}`,
+                "body": replyText,
+                "formatted_body": replyHtml,
             };
 
             const expectedContent = {
@@ -3925,9 +3913,8 @@ describe('MatrixClient', () => {
                 },
                 "msgtype": "m.notice",
                 "format": "org.matrix.custom.html",
-                "body": `> <${originalEvent.sender}> ${originalEvent.content.body}\n\n${replyText}`,
-                // eslint-disable-next-line max-len
-                "formatted_body": `<mx-reply><blockquote><a href="https://matrix.to/#/${roomId}/${originalEvent.event_id}">In reply to</a> <a href="https://matrix.to/#/${originalEvent.sender}">${originalEvent.sender}</a><br />${originalEvent.content.formatted_body}</blockquote></mx-reply>${replyHtml}`,
+                "body": replyText,
+                "formatted_body": replyHtml,
             };
 
             client.crypto.isRoomEncrypted = async () => false; // for this test
@@ -3944,7 +3931,7 @@ describe('MatrixClient', () => {
             expect(result).toEqual(eventId);
         }));
 
-        it('should use encoded plain text as the HTML component', async () => {
+        it('should omit HTML when replying with plain text', async () => {
             const { client, http, hsUrl } = createTestClient();
 
             const roomId = "!testing:example.org";
@@ -3958,7 +3945,6 @@ describe('MatrixClient', () => {
                 event_id: "$abc:example.org",
             };
             const replyText = "<testing1234>";
-            const replyHtml = "&lt;testing1234&gt;";
 
             const expectedContent = {
                 "m.relates_to": {
@@ -3967,10 +3953,7 @@ describe('MatrixClient', () => {
                     },
                 },
                 "msgtype": "m.notice",
-                "format": "org.matrix.custom.html",
-                "body": `> <${originalEvent.sender}> ${originalEvent.content.body}\n\n${replyText}`,
-                // eslint-disable-next-line max-len
-                "formatted_body": `<mx-reply><blockquote><a href="https://matrix.to/#/${roomId}/${originalEvent.event_id}">In reply to</a> <a href="https://matrix.to/#/${originalEvent.sender}">${originalEvent.sender}</a><br />${originalEvent.content.formatted_body}</blockquote></mx-reply>${replyHtml}`,
+                "body": replyText,
             };
 
             // noinspection TypeScriptValidateJSTypes
@@ -4011,9 +3994,8 @@ describe('MatrixClient', () => {
                 },
                 "msgtype": "m.notice",
                 "format": "org.matrix.custom.html",
-                "body": `> <${originalEvent.sender}> ${originalEvent.content.body}\n\n${replyText}`,
-                // eslint-disable-next-line max-len
-                "formatted_body": `<mx-reply><blockquote><a href="https://matrix.to/#/${roomId}/${originalEvent.event_id}">In reply to</a> <a href="https://matrix.to/#/${originalEvent.sender}">${originalEvent.sender}</a><br />${originalEvent.content.formatted_body}</blockquote></mx-reply>${replyHtml}`,
+                "body": replyText,
+                "formatted_body": replyHtml,
             };
 
             // noinspection TypeScriptValidateJSTypes
@@ -4052,9 +4034,8 @@ describe('MatrixClient', () => {
                 },
                 "msgtype": "m.notice",
                 "format": "org.matrix.custom.html",
-                "body": `> <${originalEvent.sender}> ${originalEvent.content.body}\n\n${replyText}`,
-                // eslint-disable-next-line max-len
-                "formatted_body": `<mx-reply><blockquote><a href="https://matrix.to/#/${roomId}/${originalEvent.event_id}">In reply to</a> <a href="https://matrix.to/#/${originalEvent.sender}">${originalEvent.sender}</a><br />${originalEvent.content.formatted_body}</blockquote></mx-reply>${replyHtml}`,
+                "body": replyText,
+                "formatted_body": replyHtml,
             };
 
             const expectedContent = {
@@ -4105,9 +4086,8 @@ describe('MatrixClient', () => {
                 },
                 "msgtype": "m.notice",
                 "format": "org.matrix.custom.html",
-                "body": `> <${originalEvent.sender}> ${originalEvent.content.body}\n\n${replyText}`,
-                // eslint-disable-next-line max-len
-                "formatted_body": `<mx-reply><blockquote><a href="https://matrix.to/#/${roomId}/${originalEvent.event_id}">In reply to</a> <a href="https://matrix.to/#/${originalEvent.sender}">${originalEvent.sender}</a><br />${originalEvent.content.formatted_body}</blockquote></mx-reply>${replyHtml}`,
+                "body": replyText,
+                "formatted_body": replyHtml,
             };
 
             client.crypto.isRoomEncrypted = async () => false; // for this test

--- a/test/helpers/RichReplyTest.ts
+++ b/test/helpers/RichReplyTest.ts
@@ -23,10 +23,9 @@ describe('RichReply', () => {
                 },
             },
             "msgtype": "m.text",
-            "body": `> <${inputEvent.sender}> ${inputEvent.content.body}\n\n${replyText}`,
+            "body": replyText,
             "format": "org.matrix.custom.html",
-            // eslint-disable-next-line max-len
-            "formatted_body": `<mx-reply><blockquote><a href="https://matrix.to/#/${inputRoomId}/${inputEvent.event_id}">In reply to</a> <a href="https://matrix.to/#/${inputEvent.sender}">${inputEvent.sender}</a><br />${inputEvent.content.formatted_body}</blockquote></mx-reply>${replyHtml}`,
+            "formatted_body": replyHtml,
         };
 
         expect(reply).toMatchObject(expectedReply);
@@ -54,10 +53,9 @@ describe('RichReply', () => {
                 },
             },
             "msgtype": "m.text",
-            "body": `> <${inputEvent.sender}> ${inputEvent.content.body.split('\n').join('\n> ')}\n\n${replyText}`,
+            "body": replyText,
             "format": "org.matrix.custom.html",
-            // eslint-disable-next-line max-len
-            "formatted_body": `<mx-reply><blockquote><a href="https://matrix.to/#/${inputRoomId}/${inputEvent.event_id}">In reply to</a> <a href="https://matrix.to/#/${inputEvent.sender}">${inputEvent.sender}</a><br />${inputEvent.content.formatted_body}</blockquote></mx-reply>${replyHtml}`,
+            "formatted_body": replyHtml,
         };
 
         expect(reply).toMatchObject(expectedReply);
@@ -73,9 +71,8 @@ describe('RichReply', () => {
         };
         const inputRoomId = "!abc:example.org";
         const replyText = "**Testing 1234**";
-        const replyHtml = "<b>Testing 1234</b>";
 
-        const reply = RichReply.createFor(inputRoomId, inputEvent, replyText, replyHtml);
+        const reply = RichReply.createFor(inputRoomId, inputEvent, replyText);
 
         const expectedReply = {
             "m.relates_to": {
@@ -84,10 +81,7 @@ describe('RichReply', () => {
                 },
             },
             "msgtype": "m.text",
-            "body": `> <${inputEvent.sender}> ${inputEvent.content.body}\n\n${replyText}`,
-            "format": "org.matrix.custom.html",
-            // eslint-disable-next-line max-len
-            "formatted_body": `<mx-reply><blockquote><a href="https://matrix.to/#/${inputRoomId}/${inputEvent.event_id}">In reply to</a> <a href="https://matrix.to/#/${inputEvent.sender}">${inputEvent.sender}</a><br />${inputEvent.content.body}</blockquote></mx-reply>${replyHtml}`,
+            "body": replyText,
         };
 
         expect(reply).toMatchObject(expectedReply);

--- a/yarn.lock
+++ b/yarn.lock
@@ -3535,11 +3535,6 @@ html-to-text@^9.0.5:
     htmlparser2 "^8.0.2"
     selderee "^0.11.0"
 
-htmlencode@^0.0.4:
-  version "0.0.4"
-  resolved "https://registry.yarnpkg.com/htmlencode/-/htmlencode-0.0.4.tgz#f7e2d6afbe18a87a78e63ba3308e753766740e3f"
-  integrity sha512-0uDvNVpzj/E2TfvLLyyXhKBRvF1y84aZsyRxRXFsQobnHaL4pcaXk+Y9cnFlvnxrBLeXDNq/VJBD+ngdBgQG1w==
-
 htmlparser2@^8.0.0, htmlparser2@^8.0.2:
   version "8.0.2"
   resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-8.0.2.tgz#f002151705b383e62433b5cf466f5b716edaec21"


### PR DESCRIPTION
Since v1.13 of the spec, rich replies no longer include a fallback representation of the original message, so stop generating them.

This also allows dropping the htmlencode dependency, which is used only for generating such fallbacks.

<!-- Thanks for submitting a PR! Please ensure the following requirements are met in order for us to review your PR -->

## Checklist

* [x] Tests written for all new code
* [x] Linter has been satisfied
* [ ] Sign-off given on the changes (see CONTRIBUTING.md)
